### PR TITLE
#97 - Changed CMD+E to show Recent Files not Recent Projects popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Port of IntelliJ IDEA key bindings for VS Code. Includes keymaps for popular Jet
 ### Editing
 
 Linux, Windows | macOS | Feature | Supported
----------------|------|---------|---------- 
+---------------|------|---------|----------
 ctrl+space | ctrl+space | Basic code completion (the name of any class, method or variable) | ✅
-ctrl+shift+space | ctrl+shift+space | Smart code completion (filters the list of methods and variables by expected type) | N/A
+ctrl+shift+space | ctrl+shift+space | Smart code completion (filters the list of methods and variables by expected type)| N/A
 ctrl+shift+enter | cmd+shift+enter | Complete statement | ✅
 ctrl+p | cmd+p | Parameter info (within method call arguments) | ✅
 ctrl+q | ctrl+j | Quick documentation lookup | ✅
@@ -67,7 +67,7 @@ alt+shift+j | ctrl+shift+g | Unselect Occurrence | ✅
 ### Search/Replace
 
 Linux, Windows | macOS | Feature | Supported
----------------|------|---------|---------- 
+---------------|------|---------|----------
 shift shift | shift shift | Search everywhere | N/A
 ctrl+f | cmd+f | Find | ✅
 f3 | cmd+g | Find next | ✅
@@ -81,7 +81,7 @@ ctrl+shift+m | cmd+shift+m | Replace structurally (Ultimate Edition only) | N/A
 ### Usage Search
 
 Linux, Windows | macOS | Feature | Supported
----------------|------|---------|---------- 
+---------------|------|---------|----------
 alt+f7 | alt+f7 | Find usages | ✅
 ctrl+f7 | cmd+f7 | Find usages in file | N/A
 ctrl+shift+f7 | cmd+shift+f7 | Highlight usages in file | N/A
@@ -90,7 +90,7 @@ ctrl+alt+f7 | cmd+alt+f7 | Show usages | N/A
 ### Compile and Run
 
 Linux, Windows | macOS | Feature | Supported
----------------|------|---------|---------- 
+---------------|------|---------|----------
 ctrl+f9 | cmd+f9 | Make project (compile modifed and dependent) | ✅
 ctrl+shift+f9 | cmd+shift+f9 | Compile selected file, package or module | N/A
 alt+shift+f10 | ctrl+alt+r | Select configuration and run | ✅
@@ -103,7 +103,7 @@ ctrl+shift+f10 | ctrl+shift+r | Debug context configuration from editor | N/A
 ### Debugging
 
 Linux, Windows | macOS | Feature | Supported
----------------|------|---------|---------- 
+---------------|------|---------|----------
 f8 | f8 | Step over | ✅
 f7 | f7 | Step into | ✅
 shift+f7 | shift+f7 | Smart step into | N/A
@@ -118,7 +118,7 @@ ctrl+shift+f8 | cmd+shift+f8 | View breakpoints | ✅
 ### Navigation
 
 Linux, Windows | macOS | Feature | Supported
----------------|------|---------|---------- 
+---------------|------|---------|----------
 ctrl+n | cmd+o | Go to class | ✅
 ctrl+shift+n | cmd+shift+o | Go to file | ✅
 ctrl+alt+shift+n | cmd+alt+o | Go to symbol | ✅
@@ -172,7 +172,7 @@ shift+f11 | cmd+f3 | Show bookmarks | N/A
 ### Refactoring
 
 Linux, Windows | macOS | Feature | Supported
----------------|------|---------|---------- 
+---------------|------|---------|----------
 f5 | f5 | Copy | N/A
 f6 | f6 | Move | N/A
 alt+delete | cmd+delete | Safe Delete | N/A
@@ -189,7 +189,7 @@ ctrl+alt+p | cmd+alt+p | Extract Parameter | N/A
 ### VCS/Local History
 
 Linux, Windows | macOS | Feature | Supported
----------------|------|---------|---------- 
+---------------|------|---------|----------
 ctrl+k | cmd+k | Commit project to VCS | ✅
 ctrl+t | cmd+t | Update project from VCS | ✅
 alt+shift+c | alt+shift+c | View recent changes | N/A
@@ -198,14 +198,14 @@ ctrl+\` | ctrl+v | ‘VCS’ quick popup | ✅
 ### Live Templates
 
 Linux, Windows | macOS | Feature | Supported
----------------|------|---------|---------- 
+---------------|------|---------|----------
 ctrl+alt+j | cmd+alt+j | Surround with Live Template | N/A
 ctrl+j | cmd+j | Insert Live Template | N/A
 
 ### General
 
 Linux, Windows | macOS | Feature | Supported
----------------|------|---------|---------- 
+---------------|------|---------|----------
 alt+0 | cmd+0 | Activate Messages window (Problems) | ✅
 alt+numpad0 | cmd+numpad0 | Activate Messages window (Problems) | ✅
 alt+1 | cmd+1 | Open corresponding tool window (Explorer) | ✅
@@ -240,7 +240,7 @@ ctrl+tab | ctrl+tab | Switch between tabs and tool window | ✅
 ### Custom
 
 Linux, Windows | macOS | Feature | Supported
----------------|------|---------|---------- 
+---------------|------|---------|----------
 f7 | f7 | Next difference | ✅
 shift+f7 | shift+f7 | Previous difference | ✅
 alt+ctrl+enter | alt+cmd+enter | Start new line before current | ✅

--- a/package.json
+++ b/package.json
@@ -45,6 +45,9 @@
     },
     "contributes": {
         "keybindings": [
+
+
+
             {
                 "key": "ctrl+space",
                 "mac": "ctrl+space",
@@ -52,6 +55,16 @@
                 "when": "editorHasCompletionItemProvider && editorTextFocus && !editorReadonly",
                 "intellij": "Basic code completion (the name of any class, method or variable)"
             },
+
+
+
+
+
+
+
+
+
+
             {
                 "key": "ctrl+shift+enter",
                 "mac": "cmd+shift+enter",
@@ -73,6 +86,26 @@
                 "when": "editorTextFocus",
                 "intellij": "Quick documentation lookup"
             },
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
             {
                 "key": "ctrl+f1",
                 "mac": "cmd+f1",
@@ -87,6 +120,36 @@
                 "when": "!editorTextFocus",
                 "intellij": "Generate code... (Getters, Setters, Constructors, hashCode/equals, toString)"
             },
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
             {
                 "key": "ctrl+/",
                 "mac": "cmd+/",
@@ -129,6 +192,16 @@
                 "when": "editorTextFocus",
                 "intellij": "Decrease current selection to previous state"
             },
+
+
+
+
+
+
+
+
+
+
             {
                 "key": "alt+enter",
                 "mac": "alt+enter",
@@ -150,6 +223,44 @@
                 "when": "editorHasDocumentFormattingProvider && editorHasSelection && editorTextFocus && !editorReadonly",
                 "intellij": "Reformat selected code"
             },
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
             {
                 "key": "ctrl+x",
                 "mac": "cmd+x",
@@ -178,6 +289,16 @@
                 "when": "editorTextFocus && !editorReadonly",
                 "intellij": "Paste from clipboard"
             },
+
+
+
+
+
+
+
+
+
+
             {
                 "key": "ctrl+d",
                 "mac": "cmd+d",
@@ -213,6 +334,36 @@
                 "when": "editorTextFocus && !editorReadonly",
                 "intellij": "Start new line"
             },
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
             {
                 "key": "ctrl+delete",
                 "mac": "alt+delete",
@@ -303,6 +454,18 @@
                 "when": "editorTextFocus",
                 "intellij": "Unselect Occurrence"
             },
+
+
+
+
+
+
+
+
+
+
+
+
             {
                 "key": "ctrl+f",
                 "mac": "cmd+f",
@@ -342,6 +505,27 @@
                 "command": "workbench.action.replaceInFiles",
                 "intellij": "Replace in path"
             },
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
             {
                 "key": "alt+f7",
                 "mac": "alt+f7",
@@ -349,12 +533,54 @@
                 "when": "editorHasReferenceProvider && editorTextFocus && !inReferenceSearchEditor",
                 "intellij": "Find usages"
             },
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
             {
                 "key": "ctrl+f9",
                 "mac": "cmd+f9",
                 "command": "workbench.action.tasks.build",
                 "intellij": "Make project (compile modifed and dependent)"
             },
+
+
+
+
+
+
+
+
+
             {
                 "key": "alt+shift+f10",
                 "mac": "ctrl+alt+r",
@@ -367,6 +593,15 @@
                 "command": "workbench.view.debug",
                 "intellij": "Select configuration and debug"
             },
+
+
+
+
+
+
+
+
+
             {
                 "key": "shift+f9",
                 "mac": "ctrl+d",
@@ -374,6 +609,27 @@
                 "when": "!inDebugMode && !terminalFocus",
                 "intellij": "Debug"
             },
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
             {
                 "key": "f8",
                 "mac": "f8",
@@ -388,6 +644,16 @@
                 "when": "inDebugMode",
                 "intellij": "Step into"
             },
+
+
+
+
+
+
+
+
+
+
             {
                 "key": "shift+f8",
                 "mac": "shift+f8",
@@ -406,12 +672,14 @@
                 "key": "alt+f8",
                 "mac": "alt+f8",
                 "command": "workbench.debug.action.toggleRepl",
+
                 "intellij": "Evaluate expression"
             },
             {
                 "key": "alt+f8",
                 "mac": "alt+f8",
                 "command": "editor.debug.action.selectionToRepl",
+
                 "when": "editorTextFocus && editorHasSelection",
                 "intellij": "Evaluate expression (selection)"
             },
@@ -436,6 +704,9 @@
                 "intellij": "View breakpoints",
                 "todo": "show all debug"
             },
+
+
+
             {
                 "key": "ctrl+n",
                 "mac": "cmd+o",
@@ -479,6 +750,24 @@
                 "command": "workbench.action.nextEditor",
                 "intellij": "Go to next editor tab"
             },
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
             {
                 "key": "shift+escape",
                 "mac": "shift+escape",
@@ -486,6 +775,15 @@
                 "when": "!editorFocus && !terminalFocus && !problemFocus && !inDebugRepl",
                 "intellij": "Hide active or last active window (Sidebar)"
             },
+
+
+
+
+
+
+
+
+
             {
                 "key": "shift+escape",
                 "mac": "shift+escape",
@@ -507,6 +805,25 @@
                 "when": "terminalFocus",
                 "intellij": "Hide active or last active window (Terminal)"
             },
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
             {
                 "key": "ctrl+g",
                 "mac": "cmd+l",
@@ -516,8 +833,24 @@
             {
                 "key": "ctrl+e",
                 "mac": "cmd+e",
-                "command": "workbench.action.openRecent",
+                "command": "-actions.find"
+            },
+            {
+                "key": "ctrl+e",
+                "mac": "cmd+e",
+                "command": "-workbench.action.openRecent"
+            },
+            {
+                "key": "ctrl+e",
+                "mac": "cmd+e",
+                "command": "workbench.action.quickOpenNavigateNext",
+                "when": "inQuickOpen",
                 "intellij": "Recent files popup"
+            },
+            {
+                "key": "ctrl+e",
+                "mac": "cmd+e",
+                "command": "workbench.action.openNextRecentlyUsedEditorInGroup"
             },
             {
                 "key": "ctrl+alt+left",
@@ -543,6 +876,25 @@
                 "command": "workbench.action.navigateForward",
                 "intellij": "Navigate forward"
             },
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
             {
                 "key": "ctrl+b",
                 "mac": "cmd+b",
@@ -579,6 +931,56 @@
                 "intellij": "Go to type declaration",
                 "todo": "not working"
             },
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
             {
                 "key": "ctrl+f12",
                 "mac": "cmd+f12",
@@ -586,6 +988,54 @@
                 "when": "editorTextFocus",
                 "intellij": "File structure popup"
             },
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
             {
                 "key": "f4",
                 "mac": "f4",
@@ -614,6 +1064,85 @@
                 "when": "editorTextFocus && !editorReadonly",
                 "intellij": "Move Statement Up"
             },
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
             {
                 "key": "shift+f6",
                 "mac": "shift+f6",
@@ -628,6 +1157,79 @@
                 "when": "explorerViewletVisible && filesExplorerFocus",
                 "intellij": "Rename (File)"
             },
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
             {
                 "key": "ctrl+k",
                 "mac": "cmd+k",
@@ -641,6 +1243,15 @@
                 "command": "workbench.action.git.sync",
                 "intellij": "Update project from VCS"
             },
+
+
+
+
+
+
+
+
+
             {
                 "key": "ctrl+`",
                 "mac": "ctrl+v",
@@ -648,6 +1259,30 @@
                 "intellij": "‘VCS’ quick popup",
                 "todo": "no popup"
             },
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
             {
                 "key": "alt+0",
                 "mac": "cmd+0",
@@ -797,6 +1432,24 @@
                 "intellij": "Toggle maximizing editor",
                 "todo": "toggle not working"
             },
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
             {
                 "key": "ctrl+`",
                 "mac": "ctrl+`",
@@ -834,6 +1487,9 @@
                 "when": "inQuickOpen",
                 "intellij": "Switch between tabs and tool window"
             },
+
+
+
             {
                 "key": "f7",
                 "mac": "f7",

--- a/src/package-with-comment.json
+++ b/src/package-with-comment.json
@@ -57,8 +57,8 @@
             },
             /*
             {
-                "key": "ctrl+shft+space",
-                "mac": "ctrl+shft+space",
+                "key": "ctrl+shift+space",
+                "mac": "ctrl+shift+space",
                 "command": "",
                 "when": "",
                 "intellij": "Smart code completion (filters the list of methods and variables by expected type)",
@@ -459,8 +459,8 @@
             \*---------------------------------------------------------------*/
             /*
             {
-                "key": "shfit shift",
-                "mac": "shfit shift",
+                "key": "shift shift",
+                "mac": "shift shift",
                 "command": "",
                 "intellij": "Search everywhere",
                 "todo": "N/A: shift shift"
@@ -830,11 +830,27 @@
                 "command": "workbench.action.gotoLine",
                 "intellij": "Go to line"
             },
+            {   
+                "key": "ctrl+e",                 
+                "mac": "cmd+e",                 
+                "command": "-actions.find" 
+            },
+            { 
+                "key": "ctrl+e",                
+                "mac": "cmd+e",                
+                "command": "-workbench.action.openRecent" 
+            },
             {
                 "key": "ctrl+e",
                 "mac": "cmd+e",
-                "command": "workbench.action.openRecent",
+                "command": "workbench.action.quickOpenNavigateNext",
+                "when": "inQuickOpen",
                 "intellij": "Recent files popup"
+            },
+            { 
+                "key": "ctrl+e",              
+                "mac": "cmd+e",              
+                "command": "workbench.action.openNextRecentlyUsedEditorInGroup" 
             },
             {
                 "key": "ctrl+alt+left",


### PR DESCRIPTION
Replaced `workbench.action.openRecent` command with `workbench.action.quickOpenNavigateNext` that better reflects IntelliJ's `CMD+E` shortcut's behaviour

Edit: Turns out the problems with shortcuts not working often occurs when too many actions are bound to a single shortcut. In case of `CMD+E`, to make it work I had to remove the default binding to `actions.find` and `workbench.action.openRecent`.