### PR TITLE
Fix terminal focus

### DIFF
--- a/package.json
+++ b/package.json
@@ -902,8 +902,16 @@
             {
                 "key": "alt+f12",
                 "mac": "alt+f12",
+                "command": "workbench.action.terminal.focus",
+                "when": "!terminalFocus",
+                "intellij": "Opens and focuses corresponding tool window (Terminal)"
+            },
+            {
+                "key": "alt+f12",
+                "mac": "alt+f12",
                 "command": "workbench.action.terminal.toggleTerminal",
-                "intellij": "Open corresponding tool window (Terminal)"
+                "when": "terminalFocus",
+                "intellij": "Close corresponding tool window (Terminal)"
             },
             {
                 "key": "ctrl+shift+alt+j",

--- a/src/package-with-comment.json
+++ b/src/package-with-comment.json
@@ -1543,7 +1543,15 @@
                 "key": "alt+f12",
                 "mac": "alt+f12",
                 "command": "workbench.action.terminal.focus",
+                "when": "!terminalFocus",
                 "intellij": "Opens and focuses corresponding tool window (Terminal)"
+            },
+            {
+                "key": "alt+f12",
+                "mac": "alt+f12",
+                "command": "workbench.action.terminal.toggleTerminal",
+                "when": "terminalFocus",
+                "intellij": "Close corresponding tool window (Terminal)"
             },
             {
                 "key": "ctrl+shift+alt+j",

--- a/src/package-with-comment.json
+++ b/src/package-with-comment.json
@@ -1542,8 +1542,8 @@
             {
                 "key": "alt+f12",
                 "mac": "alt+f12",
-                "command": "workbench.action.terminal.toggleTerminal",
-                "intellij": "Open corresponding tool window (Terminal)"
+                "command": "workbench.action.terminal.focus",
+                "intellij": "Opens and focuses corresponding tool window (Terminal)"
             },
             {
                 "key": "ctrl+shift+alt+j",


### PR DESCRIPTION
Should be ```workbench.action.terminal.focus``` because the present command implementation ```workbench.action.terminal.toggleTerminal``` actually toggles the terminal but it does not focus it like it does on IntelliJ.