### PR TITLE
Fixed triggerSuggest condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ when changes are saved.
 * [@michielboekhoff](https://github.com/michielboekhoff)
 * [@thekalinga](https://github.com/thekalinga)
 * [@andrewda](https://github.com/andrewda)
+* [@deftomat](https://github.com/deftomat)
 
 
 ## License

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "intellij-idea-keybindings",
-    "version": "0.2.25",
+    "version": "0.2.24",
     "publisher": "k--kato",
     "engines": {
         "vscode": "^1.23.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "intellij-idea-keybindings",
-    "version": "0.2.24",
+    "version": "0.2.25",
     "publisher": "k--kato",
     "engines": {
         "vscode": "^1.23.0"
@@ -49,7 +49,7 @@
                 "key": "ctrl+space",
                 "mac": "ctrl+space",
                 "command": "editor.action.triggerSuggest",
-                "when": "editorHasCompletionItemProvider && editorTextFocus && !editorReadonly",
+                "when": "editorHasCompletionItemProvider && textInputFocus && !editorReadonly",
                 "intellij": "Basic code completion (the name of any class, method or variable)"
             },
             {

--- a/src/package-with-comment.json
+++ b/src/package-with-comment.json
@@ -52,7 +52,7 @@
                 "key": "ctrl+space",
                 "mac": "ctrl+space",
                 "command": "editor.action.triggerSuggest",
-                "when": "editorHasCompletionItemProvider && editorTextFocus && !editorReadonly",
+                "when": "editorHasCompletionItemProvider && textInputFocus && !editorReadonly",
                 "intellij": "Basic code completion (the name of any class, method or variable)"
             },
             /*


### PR DESCRIPTION
I slightly updated a `when` condition in triggerSuggest command.
Now, it looks like the default one in VSCode. There was two triggerSuggest bindings to the same `ctrl+space` but only with different `when` condition.

This was causing a *loading* message when you hit `ctrl+space` right after VSCode showed suggestions:
![1okuguysdh](https://user-images.githubusercontent.com/5549148/44643403-b1700380-a9d0-11e8-9b22-abf1440f4b0c.gif)

Now, it should behave normally.
