### PR TITLE
Removed triggerSuggest keybinding

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,13 +46,6 @@
     "contributes": {
         "keybindings": [
             {
-                "key": "ctrl+space",
-                "mac": "ctrl+space",
-                "command": "editor.action.triggerSuggest",
-                "when": "editorHasCompletionItemProvider && textInputFocus && !editorReadonly",
-                "intellij": "Basic code completion (the name of any class, method or variable)"
-            },
-            {
                 "key": "ctrl+shift+enter",
                 "mac": "cmd+shift+enter",
                 "command": "acceptSelectedSuggestion",

--- a/src/package-with-comment.json
+++ b/src/package-with-comment.json
@@ -48,6 +48,7 @@
             /*---------------------------------------------------------------*\
              * Editing
             \*---------------------------------------------------------------*/
+            /*
             {
                 "key": "ctrl+space",
                 "mac": "ctrl+space",
@@ -55,6 +56,7 @@
                 "when": "editorHasCompletionItemProvider && textInputFocus && !editorReadonly",
                 "intellij": "Basic code completion (the name of any class, method or variable)"
             },
+*/
             /*
             {
                 "key": "ctrl+shift+space",


### PR DESCRIPTION
As a continuation of https://github.com/kasecato/vscode-intellij-idea-keybindings/pull/122.

I tried the latest version and it looks like VSCode doesn't merge the same keybindings. It creates two identical instead. 

So, we need to remove it from this package to make it works properly.