### PR TITLE
Alt Home hotkey for focusing the breadcrumbs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/kasecato/vscode-intellij-idea-keybindings.svg?branch=master)](https://travis-ci.org/kasecato/vscode-intellij-idea-keybindings) [![License: MIT](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE.md) [![Marketplace Version](https://vsmarketplacebadge.apphb.com/version/k--kato.intellij-idea-keybindings.svg)](https://marketplace.visualstudio.com/items?itemName=k--kato.intellij-idea-keybindings) [![Install](https://vsmarketplacebadge.apphb.com/installs-short/k--kato.intellij-idea-keybindings.svg)](https://marketplace.visualstudio.com/items?itemName=k--kato.intellij-idea-keybindings)
 
-Port of IntelliJ IDEA key bindings for VS Code. Includes keymaps for popular JetBrains products like IntelliJ Ultimate, WebStorm, PyCharm, PHP Storm, etc. 
+Port of IntelliJ IDEA key bindings for VS Code. Includes keymaps for popular JetBrains products like IntelliJ Ultimate, WebStorm, PyCharm, PHP Storm, etc.
 
 ## Usage
 
@@ -258,6 +258,7 @@ alt+right | shift+cmd+] | Select next tab (Terminal) | ✅
 alt+tab | alt+tab | Goto next splitter | ✅
 shift+alt+tab | shift+alt+tab | Goto previous splitter | ✅
 enter | enter | Open Highlighted File (Explorer) | ✅
+alt+home | alt+home | Jump to Navigation Bar | ✅
 
 ## Installation
 
@@ -320,6 +321,7 @@ when changes are saved.
 * [@thekalinga](https://github.com/thekalinga)
 * [@andrewda](https://github.com/andrewda)
 * [@deftomat](https://github.com/deftomat)
+* [@rinormaloku](https://github.com/rinormaloku)
 
 
 ## License

--- a/package.json
+++ b/package.json
@@ -1004,6 +1004,13 @@
                 "command": "list.select",
                 "intellij": "Open Highlighted File (Explorer)",
                 "when": "explorerViewletVisible && filesExplorerFocus && !explorerResourceIsFolder"
+            },
+            {
+                "key": "alt+home",
+                "mac": "alt+home",
+                "command": "breadcrumbs.focus",
+                "intellij": "Jump to Navigation Bar",
+                "when": "editorFocus"
             }
         ]
     }

--- a/src/package-with-comment.json
+++ b/src/package-with-comment.json
@@ -1615,6 +1615,13 @@
                 "command": "list.select",
                 "intellij": "Open Highlighted File (Explorer)",
                 "when": "explorerViewletVisible && filesExplorerFocus && !explorerResourceIsFolder"
+            },
+            {
+                "key": "alt+home",
+                "mac": "alt+home",
+                "command": "breadcrumbs.focus",
+                "intellij": "Jump to Navigation Bar",
+                "when": "editorFocus"
             }
         ]
     }


### PR DESCRIPTION
Resolves issue #127 

IntelliJ has the hotkey for Alt+Home for getting into the breadcrumbs, this functionality is added in VS Code as well now.