### PR TITLE
Fix cmd+n not opening new untitled file

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
             {
                 "key": "alt+insert",
                 "mac": "cmd+n",
-                "command": "-workbench.action.files.newUntitledFile"
+                "command": "workbench.action.files.newUntitledFile"
             },
             {
                 "key": "ctrl+/",


### PR DESCRIPTION
I think this should fix the cmd+n not opening a new untitled file