### PR TITLE
Add column selection shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ alt+j | ctrl+g | Add selection for Next Occurrence | ✅
 alt+shift+j | ctrl+shift+g | Unselect Occurrence | ✅
 shift+alt+down | shift+alt+down | Move Line Down | ✅
 shift+alt+up | shift+alt+up | Move Line Up | ✅
+shift+ctrl+8 | shift+cmd+8 | Column Selection Mode | ✅
 
 ### Search/Replace
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "intellij-idea-keybindings",
-    "version": "0.2.37",
+    "version": "0.2.38",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -330,6 +330,12 @@
                 "intellij": "Move Line Up"
             },
             {
+                "key": "shift+ctrl+8",
+                "mac": "shift+cmd+8",
+                "command": "editor.action.toggleColumnSelection",
+                "intellij": "Column Selection Mode"
+            },
+            {
                 "key": "f3",
                 "mac": "cmd+g",
                 "command": "editor.action.nextMatchFindAction",

--- a/src/package-with-comment.json
+++ b/src/package-with-comment.json
@@ -518,6 +518,12 @@
                 "when": "editorTextFocus && !editorReadonly",
                 "intellij": "Move Line Up"
             },
+            {
+                "key": "shift+ctrl+8",
+                "mac": "shift+cmd+8",
+                "command": "editor.action.toggleColumnSelection",
+                "intellij": "Column Selection Mode"
+            },
             /*---------------------------------------------------------------*\
              * Search/Replace
             \*---------------------------------------------------------------*/


### PR DESCRIPTION
Add `Column Selection Mode` shortcut.
- Linux/Windows: <kbd>Shift</kbd> + <kbd>Ctrl</kbd> + <kbd>8</kbd>
- Mac: <kbd>Shift</kbd> + <kbd>Cmd</kbd> + <kbd>8</kbd>