### PR TITLE
fixes Ctrl/Cmd+Shift+F due to change in VSCode

### DIFF
--- a/package.json
+++ b/package.json
@@ -401,8 +401,7 @@
             {
                 "key": "ctrl+shift+f",
                 "mac": "cmd+shift+f",
-                "command": "workbench.view.search",
-                "when": "!searchViewletVisible",
+                "command": "workbench.action.findInFiles",
                 "intellij": "Find in path"
             },
             {

--- a/resource/default/Linux/VSCode.json
+++ b/resource/default/Linux/VSCode.json
@@ -202,8 +202,7 @@
     },
     {
         "key": "ctrl+shift+f",
-        "command": "workbench.view.search",
-        "when": "!searchViewletVisible"
+        "command": "workbench.action.findInFiles"
     },
     {
         "key": "ctrl+shift+h",
@@ -451,11 +450,6 @@
     {
         "key": "ctrl+b",
         "command": "workbench.action.toggleSidebarVisibility"
-    },
-    {
-        "key": "ctrl+shift+f",
-        "command": "workbench.view.search",
-        "when": "!searchViewletVisible"
     },
     {
         "key": "ctrl+shift+g",

--- a/resource/default/Mac/VSCode.json
+++ b/resource/default/Mac/VSCode.json
@@ -218,8 +218,7 @@
     },
     {
         "key": "shift+cmd+f",
-        "command": "workbench.view.search",
-        "when": "!searchViewletVisible"
+        "command": "workbench.action.findInFiles"
     },
     {
         "key": "shift+cmd+h",
@@ -466,11 +465,6 @@
     {
         "key": "cmd+b",
         "command": "workbench.action.toggleSidebarVisibility"
-    },
-    {
-        "key": "shift+cmd+f",
-        "command": "workbench.view.search",
-        "when": "!searchViewletVisible"
     },
     {
         "key": "cmd+b",

--- a/resource/default/Windows/VSCode.json
+++ b/resource/default/Windows/VSCode.json
@@ -210,8 +210,7 @@
       },
       {
         "key": "ctrl+shift+f",
-        "command": "workbench.view.search",
-        "when": "!searchViewletVisible"
+        "command": "workbench.action.findInFiles"
       },
       {
         "key": "ctrl+shift+h",
@@ -459,11 +458,6 @@
       {
         "key": "ctrl+b",
         "command": "workbench.action.toggleSidebarVisibility"
-      },
-      {
-        "key": "ctrl+shift+f",
-        "command": "workbench.view.search",
-        "when": "!searchViewletVisible"
       },
       {
         "key": "ctrl+b",

--- a/src/package-with-comment.json
+++ b/src/package-with-comment.json
@@ -600,8 +600,7 @@
             {
                 "key": "ctrl+shift+f",
                 "mac": "cmd+shift+f",
-                "command": "workbench.view.search",
-                "when": "!searchViewletVisible",
+                "command": "workbench.action.findInFiles",
                 "intellij": "Find in path"
             },
             {


### PR DESCRIPTION
fixes Ctrl/Cmd+Shift+F no longer filling the selected text into the search field when the search pane currently is not active

fixes https://github.com/microsoft/vscode/issues/119860

the issue was introduced by a change in VSCode: https://code.visualstudio.com/updates/v1_54#_changes-to-workspace-search-actions

related: https://github.com/alphabotsec/vscode-eclipse-keybindings/pull/39