### PR TITLE
Update the shift shift 'Search Anywhere' command to call quickOpen

### DIFF
--- a/package.json
+++ b/package.json
@@ -374,7 +374,7 @@
             {
                 "key": "shift shift",
                 "mac": "shift shift",
-                "command": "workbench.action.showCommands",
+                "command": "workbench.action.quickOpen",
                 "intellij": "Search everywhere"
             },
             {

--- a/src/package-with-comment.json
+++ b/src/package-with-comment.json
@@ -565,7 +565,7 @@
             {
                 "key": "shift shift",
                 "mac": "shift shift",
-                "command": "workbench.action.showCommands",
+                "command": "workbench.action.quickOpen",
                 "intellij": "Search everywhere"
             },
             /*


### PR DESCRIPTION
Shift shift in IntelliJ allows you to search for file names and symbols.

Whilst it isn't an exact match, workbench.action.quickOpen allows you to search by file name, and if you know the file name, also search for symbols using @.

It's not as powerful as the IntelliJ search, but I think it is a better match than bringing up the command palette?