### PR TITLE
chore: fix import command typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Port of IntelliJ IDEA key bindings for VS Code. Includes keymaps for popular Jet
 #### Import keymaps XML
 1. Launch Code
 1. Open command pallet `Ctrl`-`Shift`-`P` (Windows) or `Cmd`-`Shift`-`P` (macOS)
-1. Choose `Import IntelliJ Keybindngs (XML)`
+1. Choose `Import IntelliJ Keybindings (XML)`
 1. Copy & Paste it into `keybindings.json`
 
 ### Editing

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
         "commands": [
             {
                 "command": "intellij.importKeyMapsSchema",
-                "title": "Import IntelliJ Keybindngs (XML)",
+                "title": "Import IntelliJ Keybindings (XML)",
                 "category": "IntelliJ Keybindings"
             }
         ],

--- a/src/package-with-comment.json
+++ b/src/package-with-comment.json
@@ -62,7 +62,7 @@
         "commands": [
             {
                 "command": "intellij.importKeyMapsSchema",
-                "title": "Import IntelliJ Keybindngs (XML)",
+                "title": "Import IntelliJ Keybindings (XML)",
                 "category": "IntelliJ Keybindings"
             }
         ],


### PR DESCRIPTION
This PR just changes `Keybindngs` -> `Keybindings`