### PR TITLE
Adding the keymap keyword to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     },
     "keywords": [
         "IntelliJ",
-        "Keybinding"
+        "Keybinding",
+        "keymap"
     ],
     "dependencies": {
         "fast-xml-parser": "^3.19.0"


### PR DESCRIPTION
The keybindings created by Microsoft seem to all use the "keymap" keyword, adding this keyword here:

https://github.com/microsoft/vscode-sublime-keybindings/blob/main/package.json
https://github.com/microsoft/vscode-atom-keybindings/blob/main/package.json
