### PR TITLE
Add keymap for call hierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ alt+7 | cmd+7 | Structure | ✅
 ctrl+f12 | cmd+f12 | File structure popup | ✅
 ctrl+h | ctrl+h | Type hierarchy | N/A
 ctrl+shift+h | cmd+shift+h | Method hierarchy | N/A
-ctrl+alt+h | ctrl+alt+h | Call hierarchy | N/A
+ctrl+alt+h | ctrl+alt+h | Call hierarchy | ✅
 f2 | f2 | Next highlighted error | ✅
 shift+f2 | shift+f2 | Previous highlighted error | ✅
 f4 | f4 | Edit source | ✅

--- a/package.json
+++ b/package.json
@@ -59,15 +59,12 @@
     ],
     "main": "./out/extension",
     "contributes": {
-        "commands": [
-            {
-                "command": "intellij.importKeyMapsSchema",
-                "title": "Import IntelliJ Keybindngs (XML)",
-                "category": "IntelliJ Keybindings"
-            }
-        ],
-        "keybindings": [
-            {
+        "commands": [{
+            "command": "intellij.importKeyMapsSchema",
+            "title": "Import IntelliJ Keybindngs (XML)",
+            "category": "IntelliJ Keybindings"
+        }],
+        "keybindings": [{
                 "key": "enter",
                 "mac": "enter",
                 "command": "acceptSelectedSuggestion",
@@ -691,6 +688,13 @@
                 "command": "workbench.action.gotoSymbol",
                 "when": "editorTextFocus",
                 "intellij": "File structure popup"
+            },
+            {
+                "key": "ctrl+alt+h",
+                "mac": "ctrl+alt+h",
+                "command": "references-view.showCallHierarchy",
+                "when": "editorHasCallHierarchyProvider",
+                "intellij": "Call hierarchy"
             },
             {
                 "key": "f2",

--- a/resource/ActionIdCommandMapping.json
+++ b/resource/ActionIdCommandMapping.json
@@ -32,6 +32,10 @@
         "vscode": "workbench.action.navigateBack"
     },
     {
+        "intellij": "CallHierarchy",
+        "vscode": "references-view.showCallHierarchy"
+    },
+    {
         "intellij": "CheckinProject",
         "vscode": "git.commitAll"
     },

--- a/resource/default/Linux/IntelliJ.xml
+++ b/resource/default/Linux/IntelliJ.xml
@@ -29,6 +29,9 @@
     <keyboard-shortcut first-keystroke="shift alt left" />
     <mouse-shortcut keystroke="button4" />
   </action>
+  <action id="CallHierarchy">
+    <keyboard-shortcut first-keystroke="ctrl alt h" />
+  </action>
   <action id="CheckinProject">
     <keyboard-shortcut first-keystroke="ctrl k" />
   </action>

--- a/resource/default/Linux/VSCode.json
+++ b/resource/default/Linux/VSCode.json
@@ -703,5 +703,10 @@
     {
         "key": "ctrl+n",
         "command": "workbench.action.files.newUntitledFile"
+    },
+    {
+        "key": "shift+alt+h",
+        "command": "references-view.showCallHierarchy",
+        "when": "editorHasCallHierarchyProvider"
     }
 ]

--- a/resource/default/Mac/IntelliJ.xml
+++ b/resource/default/Mac/IntelliJ.xml
@@ -27,6 +27,9 @@
     <keyboard-shortcut first-keystroke="meta alt left" />
     <mouse-shortcut keystroke="button4" />
   </action>
+  <action id="CallHierarchy">
+    <keyboard-shortcut first-keystroke="ctrl alt h" />
+  </action>
   <action id="CheckinProject">
     <keyboard-shortcut first-keystroke="meta k" />
   </action>

--- a/resource/default/Mac/VSCode.json
+++ b/resource/default/Mac/VSCode.json
@@ -724,5 +724,10 @@
     {
         "key": "cmd+n",
         "command": "workbench.action.files.newUntitledFile"
+    },
+    {
+        "key": "shift+alt+h",
+        "command": "references-view.showCallHierarchy",
+        "when": "editorHasCallHierarchyProvider"
     }
 ]

--- a/resource/default/Windows/IntelliJ.xml
+++ b/resource/default/Windows/IntelliJ.xml
@@ -29,6 +29,9 @@
     <keyboard-shortcut first-keystroke="ctrl alt left" />
     <mouse-shortcut keystroke="button4" />
   </action>
+  <action id="CallHierarchy">
+    <keyboard-shortcut first-keystroke="ctrl alt h" />
+  </action>
   <action id="CheckinProject">
     <keyboard-shortcut first-keystroke="ctrl k" />
   </action>

--- a/resource/default/Windows/VSCode.json
+++ b/resource/default/Windows/VSCode.json
@@ -719,5 +719,10 @@
       {
         "key": "ctrl+n",
         "command": "workbench.action.files.newUntitledFile"
+      },
+      {
+          "key": "shift+alt+h",
+          "command": "references-view.showCallHierarchy",
+          "when": "editorHasCallHierarchyProvider"
       }
 ]

--- a/src/package-with-comment.json
+++ b/src/package-with-comment.json
@@ -1114,16 +1114,13 @@
                 "todo": "N/A"
             },
 */
-            /*
             {
                 "key": "ctrl+alt+h",
                 "mac": "ctrl+alt+h",
-                "command": "",
-                "when": "editorTextFocus",
-                "intellij": "Call hierarchy",
-                "todo": "N/A"
+                "command": "references-view.showCallHierarchy",
+                "when": "editorHasCallHierarchyProvider",
+                "intellij": "Call hierarchy"
             },
-*/
             {
                 "key": "f2",
                 "command": "-editor.action.rename",


### PR DESCRIPTION
Since "Show Call Hierarchy" is supported in [references-view](https://github.com/microsoft/vscode-references-view), which is the VSCode's build-in extension. We can add intellij keybindings support for call hierarchy.