### PR TITLE
add shortcut to override/implement methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ ctrl+f1 | shift+f1 | External Doc | N/A
 ctrl+mouseover | cmd+mouseover | Brief Info | N/A
 ctrl+f1 | cmd+f1 | Show descriptions of error or warning at caret | ✅
 alt+insert | cmd+n | Generate code... (Getters, Setters, Constructors, hashCode/equals, toString) | ✅
-ctrl+o | ctrl+o | Override methods | N/A
-ctrl+i | ctrl+i | Implement methods | N/A
+ctrl+o | ctrl+o | Override methods | ✅
+ctrl+i | ctrl+i | Implement methods | ✅
 ctrl+alt+t | cmd+alt+t | Surround with... (if..else, try..catch, for, synchronized, etc.) | N/A
 ctrl+/ | cmd+/ | Comment/uncomment with line comment | ✅
 ctrl+numpad_divide | cmd+numpad_divide | Comment/uncomment with line comment | ✅

--- a/package.json
+++ b/package.json
@@ -115,6 +115,26 @@
                 "command": "workbench.action.files.newUntitledFile"
             },
             {
+                "key": "ctrl+o",
+                "mac": "ctrl+o",
+                "command": "editor.action.codeAction",
+                "args": {
+                    "kind": "source.overrideMethods"
+                },
+                "when": "editorTextFocus",
+                "intellij": "Override methods"
+            },
+            {
+                "key": "ctrl+i",
+                "mac": "ctrl+i",
+                "command": "editor.action.codeAction",
+                "args": {
+                    "kind": "source.overrideMethods"
+                },
+                "when": "editorTextFocus",
+                "intellij": "Implement methods"
+            },
+            {
                 "key": "ctrl+/",
                 "mac": "cmd+/",
                 "command": "editor.action.commentLine",

--- a/src/package-with-comment.json
+++ b/src/package-with-comment.json
@@ -166,26 +166,26 @@
                 "mac": "cmd+n",
                 "command": "workbench.action.files.newUntitledFile"
             },
-            /*
             {
                 "key": "ctrl+o",
                 "mac": "ctrl+o",
-                "command": "",
-                "when": "",
-                "intellij": "Override methods",
-                "todo": "N/A"
+                "command": "editor.action.codeAction",
+                "args": {
+                    "kind": "source.overrideMethods"
+                },
+                "when": "editorTextFocus",
+                "intellij": "Override methods"
             },
-*/
-            /*
             {
                 "key": "ctrl+i",
                 "mac": "ctrl+i",
-                "command": "",
-                "when": "",
-                "intellij": "Implement methods",
-                "todo": "N/A"
+                "command": "editor.action.codeAction",
+                "args": {
+                    "kind": "source.overrideMethods"
+                },
+                "when": "editorTextFocus",
+                "intellij": "Implement methods"
             },
-*/
             /*
             {
                 "key": "ctrl+alt+t",


### PR DESCRIPTION
In vscode-java extension, it uses the same code action to override/implement methods. Without this shortcut, you can find it via 
right click -> source actions... -> override/implement methods

https://user-images.githubusercontent.com/2351748/121289468-9075c480-c917-11eb-9734-203eaed6f858.mp4

