### PR TITLE
add shortcut to optimize imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ alt+q | ctrl+shift+q | Context info | N/A
 alt+enter | alt+enter | Show intention actions and quick-fixes | ✅
 ctrl+alt+l | cmd+alt+l | Reformat code | ✅
 ctrl+alt+l | cmd+alt+l | Reformat selected code | ✅
-ctrl+alt+o | ctrl+alt+o | Optimize imports | N/A
+ctrl+alt+o | ctrl+alt+o | Optimize imports | ✅
 ctrl+alt+i | ctrl+alt+i | Auto-indent line(s) | N/A
 tab | tab | Indent selected lines | N/A
 shift+tab | shift+tab | Unindent selected lines | N/A

--- a/package.json
+++ b/package.json
@@ -196,6 +196,13 @@
                 "intellij": "Reformat selected code"
             },
             {
+                "key": "ctrl+alt+o",
+                "mac": "ctrl+alt+o",
+                "command": "editor.action.organizeImports",
+                "when": "editorTextFocus && !editorReadonly && supportedCodeAction =~ /(\\s|^)source\\.organizeImports\\b/",
+                "intellij": "Optimize imports"
+            },
+            {
                 "key": "ctrl+x",
                 "mac": "cmd+x",
                 "command": "editor.action.clipboardCutAction",

--- a/resource/ActionIdCommandMapping.json
+++ b/resource/ActionIdCommandMapping.json
@@ -380,6 +380,10 @@
         "vscode": "editor.action.triggerParameterHints"
     },
     {
+        "intellij": "OptimizeImports",
+        "vscode": "editor.action.organizeImports"
+    },
+    {
         "intellij": "PrevSplitter",
         "vscode": "workbench.action.focusPreviousGroup"
     },

--- a/resource/default/Linux/IntelliJ.xml
+++ b/resource/default/Linux/IntelliJ.xml
@@ -291,6 +291,9 @@
   <action id="NextTab">
     <keyboard-shortcut first-keystroke="alt right" />
   </action>
+  <action id="OptimizeImports">
+    <keyboard-shortcut first-keystroke="ctrl alt o" />
+  </action>
   <action id="ParameterInfo">
     <keyboard-shortcut first-keystroke="ctrl p" />
   </action>

--- a/resource/default/Linux/VSCode.json
+++ b/resource/default/Linux/VSCode.json
@@ -708,5 +708,10 @@
         "key": "shift+alt+h",
         "command": "references-view.showCallHierarchy",
         "when": "editorHasCallHierarchyProvider"
+    },
+    {
+        "key": "shift+alt+o",
+        "command": "editor.action.organizeImports",
+        "when": "editorTextFocus && !editorReadonly && supportedCodeAction =~ /(\\s|^)source\\.organizeImports\\b/"
     }
 ]

--- a/resource/default/Mac/IntelliJ.xml
+++ b/resource/default/Mac/IntelliJ.xml
@@ -309,6 +309,9 @@
     <keyboard-shortcut first-keystroke="shift meta close_bracket" />
     <keyboard-shortcut first-keystroke="ctrl right" />
   </action>
+  <action id="OptimizeImports">
+    <keyboard-shortcut first-keystroke="ctrl alt o" />
+  </action>
   <action id="ParameterInfo">
     <keyboard-shortcut first-keystroke="meta p" />
   </action>

--- a/resource/default/Mac/VSCode.json
+++ b/resource/default/Mac/VSCode.json
@@ -729,5 +729,10 @@
         "key": "shift+alt+h",
         "command": "references-view.showCallHierarchy",
         "when": "editorHasCallHierarchyProvider"
+    },
+    {
+        "key": "shift+alt+o",
+        "command": "editor.action.organizeImports",
+        "when": "editorTextFocus && !editorReadonly && supportedCodeAction =~ /(\\s|^)source\\.organizeImports\\b/"
     }
 ]

--- a/resource/default/Windows/IntelliJ.xml
+++ b/resource/default/Windows/IntelliJ.xml
@@ -287,6 +287,9 @@
   <action id="NextTab">
     <keyboard-shortcut first-keystroke="alt right" />
   </action>
+  <action id="OptimizeImports">
+    <keyboard-shortcut first-keystroke="ctrl alt o" />
+  </action>
   <action id="ParameterInfo">
     <keyboard-shortcut first-keystroke="ctrl p" />
   </action>

--- a/resource/default/Windows/VSCode.json
+++ b/resource/default/Windows/VSCode.json
@@ -724,5 +724,10 @@
           "key": "shift+alt+h",
           "command": "references-view.showCallHierarchy",
           "when": "editorHasCallHierarchyProvider"
+      },
+      {
+          "key": "shift+alt+o",
+          "command": "editor.action.organizeImports",
+          "when": "editorTextFocus && !editorReadonly && supportedCodeAction =~ /(\\s|^)source\\.organizeImports\\b/"
       }
 ]

--- a/src/package-with-comment.json
+++ b/src/package-with-comment.json
@@ -269,16 +269,13 @@
                 "when": "editorHasDocumentFormattingProvider && editorHasSelection && editorTextFocus && !editorReadonly",
                 "intellij": "Reformat selected code"
             },
-            /*
             {
                 "key": "ctrl+alt+o",
                 "mac": "ctrl+alt+o",
-                "command": "",
-                "when": "",
-                "intellij": "Optimize imports",
-                "todo": "N/A"
+                "command": "editor.action.organizeImports",
+                "when": "editorTextFocus && !editorReadonly && supportedCodeAction =~ /(\\s|^)source\\.organizeImports\\b/",
+                "intellij": "Optimize imports"
             },
-*/
             /*
             {
                 "key": "ctrl+alt+i",


### PR DESCRIPTION
VS Code provides a native command `editor.action.organizeImports`. 


https://user-images.githubusercontent.com/2351748/121293740-b3f03d80-c91e-11eb-9c4b-970c86b3beb5.mp4

