### PR TITLE
add keymap for type hierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ ctrl+] | cmd+] | Move to code block end | N/A
 ctrl+[ | cmd+[ | Move to code block start | N/A
 alt+7 | cmd+7 | Structure | ✅
 ctrl+f12 | cmd+f12 | File structure popup | ✅
-ctrl+h | ctrl+h | Type hierarchy | N/A
+ctrl+h | ctrl+h | Type hierarchy | ✅
 ctrl+shift+h | cmd+shift+h | Method hierarchy | N/A
 ctrl+alt+h | ctrl+alt+h | Call hierarchy | ✅
 f2 | f2 | Next highlighted error | ✅

--- a/package.json
+++ b/package.json
@@ -728,7 +728,7 @@
                 "key": "ctrl+h",
                 "mac": "ctrl+h",
                 "command": "java.action.showTypeHierarchy",
-                "when": "editorTextFocus",
+                "when": "editorLangId == java && editorTextFocus",
                 "intellij": "Type hierarchy"
             },
             {

--- a/package.json
+++ b/package.json
@@ -725,6 +725,13 @@
                 "intellij": "Call hierarchy"
             },
             {
+                "key": "ctrl+h",
+                "mac": "ctrl+h",
+                "command": "java.action.showTypeHierarchy",
+                "when": "editorTextFocus",
+                "intellij": "Type hierarchy"
+            },
+            {
                 "key": "f2",
                 "command": "-editor.action.rename",
                 "when": "editorHasRenameProvider && editorTextFocus && !editorReadonly"

--- a/resource/ActionIdCommandMapping.json
+++ b/resource/ActionIdCommandMapping.json
@@ -508,6 +508,10 @@
         "vscode": "editor.debug.action.toggleBreakpoint"
     },
     {
+        "intellij": "TypeHierarchy",
+        "vscode": "java.action.showTypeHierarchy"
+    },
+    {
         "intellij": "UnselectPreviousOccurrence",
         "vscode": "cursorUndo"
     },

--- a/resource/default/Linux/IntelliJ.xml
+++ b/resource/default/Linux/IntelliJ.xml
@@ -383,6 +383,9 @@
   <action id="ToggleLineBreakpoint">
     <keyboard-shortcut first-keystroke="ctrl f8" />
   </action>
+  <action id="TypeHierarchy">
+    <keyboard-shortcut first-keystroke="ctrl h" />
+  </action>
   <action id="UnselectPreviousOccurrence">
     <keyboard-shortcut first-keystroke="shift alt j" />
   </action>

--- a/resource/default/Linux/VSCode.json
+++ b/resource/default/Linux/VSCode.json
@@ -713,5 +713,10 @@
         "key": "shift+alt+o",
         "command": "editor.action.organizeImports",
         "when": "editorTextFocus && !editorReadonly && supportedCodeAction =~ /(\\s|^)source\\.organizeImports\\b/"
+    },
+    {
+        "key": "",
+        "command": "java.action.showTypeHierarchy",
+        "when": "editorLangId == java && editorTextFocus"
     }
 ]

--- a/resource/default/Mac/IntelliJ.xml
+++ b/resource/default/Mac/IntelliJ.xml
@@ -409,6 +409,9 @@
   <action id="ToggleLineBreakpoint">
     <keyboard-shortcut first-keystroke="meta f8" />
   </action>
+  <action id="TypeHierarchy">
+    <keyboard-shortcut first-keystroke="ctrl h" />
+  </action>
   <action id="UnselectPreviousOccurrence">
     <keyboard-shortcut first-keystroke="shift ctrl g" />
   </action>

--- a/resource/default/Mac/VSCode.json
+++ b/resource/default/Mac/VSCode.json
@@ -734,5 +734,10 @@
         "key": "shift+alt+o",
         "command": "editor.action.organizeImports",
         "when": "editorTextFocus && !editorReadonly && supportedCodeAction =~ /(\\s|^)source\\.organizeImports\\b/"
+    },
+    {
+        "key": "",
+        "command": "java.action.showTypeHierarchy",
+        "when": "editorLangId == java && editorTextFocus"
     }
 ]

--- a/resource/default/Windows/IntelliJ.xml
+++ b/resource/default/Windows/IntelliJ.xml
@@ -379,6 +379,9 @@
   <action id="ToggleLineBreakpoint">
     <keyboard-shortcut first-keystroke="ctrl f8" />
   </action>
+  <action id="TypeHierarchy">
+    <keyboard-shortcut first-keystroke="ctrl h" />
+  </action>
   <action id="UnselectPreviousOccurrence">
     <keyboard-shortcut first-keystroke="shift alt j" />
   </action>

--- a/resource/default/Windows/VSCode.json
+++ b/resource/default/Windows/VSCode.json
@@ -729,5 +729,10 @@
           "key": "shift+alt+o",
           "command": "editor.action.organizeImports",
           "when": "editorTextFocus && !editorReadonly && supportedCodeAction =~ /(\\s|^)source\\.organizeImports\\b/"
+      },
+      {
+          "key": "",
+          "command": "java.action.showTypeHierarchy",
+          "when": "editorLangId == java && editorTextFocus"
       }
 ]

--- a/src/package-with-comment.json
+++ b/src/package-with-comment.json
@@ -1095,7 +1095,7 @@
                 "key": "ctrl+h",
                 "mac": "ctrl+h",
                 "command": "java.action.showTypeHierarchy",
-                "when": "editorTextFocus",
+                "when": "editorLangId == java && editorTextFocus",
                 "intellij": "Type hierarchy"
             },
             /*

--- a/src/package-with-comment.json
+++ b/src/package-with-comment.json
@@ -1091,16 +1091,13 @@
                 "when": "editorTextFocus",
                 "intellij": "File structure popup"
             },
-            /*
             {
                 "key": "ctrl+h",
                 "mac": "ctrl+h",
-                "command": "",
+                "command": "java.action.showTypeHierarchy",
                 "when": "editorTextFocus",
-                "intellij": "Type hierarchy",
-                "todo": "N/A"
+                "intellij": "Type hierarchy"
             },
-*/
             /*
             {
                 "key": "ctrl+shift+h",


### PR DESCRIPTION
Type hierarchy has been supported by vscode java extension. See https://github.com/redhat-developer/vscode-java/blob/master/CHANGELOG.md#0770-april-15th-2021

https://user-images.githubusercontent.com/2351748/121294638-5230d300-c920-11eb-98ee-50389e9a613f.mp4

