### PR TITLE
`alt+insert` should have proper commands for different components

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ alt+shift+j | ctrl+shift+g | Unselect Occurrence | ✅
 shift+alt+down | shift+alt+down | Move Line Down | ✅
 shift+alt+up | shift+alt+up | Move Line Up | ✅
 shift+ctrl+8 | shift+cmd+8 | Column Selection Mode | ✅
+alt+insert | cmd+n | New... | ✅
 
 ### Search/Replace
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "intellij-idea-keybindings",
-    "version": "1.4.5",
+    "version": "1.5.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "intellij-idea-keybindings",
-            "version": "1.4.5",
+            "version": "1.5.0",
             "license": "MIT",
             "dependencies": {
                 "fast-xml-parser": "^3.21.0",

--- a/package.json
+++ b/package.json
@@ -119,11 +119,19 @@
                 "when": "editorTextFocus",
                 "intellij": "Show descriptions of error or warning at caret"
             },
-            
             {
                 "key": "alt+insert",
                 "mac": "cmd+n",
-                "command": "workbench.action.files.newUntitledFile"
+                "command": "editor.action.sourceAction",
+                "when": "editorTextFocus",
+                "intellij": "Generate code... (Getters, Setters, Constructors, hashCode/equals, toString)"
+            },
+            {
+                "key": "alt+insert",
+                "mac": "cmd+n",
+                "command": "workbench.action.files.newUntitledFile",
+                "when": "!editorTextFocus",
+                "intellij": "New..."
             },
             {
                 "key": "ctrl+o",

--- a/src/package-with-comment.json
+++ b/src/package-with-comment.json
@@ -156,20 +156,19 @@
                 "when": "editorTextFocus",
                 "intellij": "Show descriptions of error or warning at caret"
             },
-            /*
+            {
+                "key": "alt+insert",
+                "mac": "cmd+n",
+                "command": "editor.action.sourceAction",
+                "when": "editorTextFocus",
+                "intellij": "Generate code... (Getters, Setters, Constructors, hashCode/equals, toString)"
+            },
             {
                 "key": "alt+insert",
                 "mac": "cmd+n",
                 "command": "workbench.action.files.newUntitledFile",
                 "when": "!editorTextFocus",
-                "intellij": "Generate code... (Getters, Setters, Constructors, hashCode/equals, toString)",
-                "todo": "N/A"
-            },
-            */
-            {
-                "key": "alt+insert",
-                "mac": "cmd+n",
-                "command": "workbench.action.files.newUntitledFile"
+                "intellij": "New..."
             },
             {
                 "key": "ctrl+o",


### PR DESCRIPTION
In IntelliJ, if the mouse focuses on the editor, the key `alt+insert` should open a Generate code... menu (Source Action in VS Code), but if the mouse focuses on the project explorer, the key should open a new file menu. This PR tries to fix it.

![sourceaction](https://user-images.githubusercontent.com/45906942/156112557-c27e6ed6-7457-486a-bd4e-33968e1f42a0.gif)
