### PR TITLE
fix column selection mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ alt+j | ctrl+g | Add selection for Next Occurrence | ✅
 alt+shift+j | ctrl+shift+g | Unselect Occurrence | ✅
 shift+alt+down | shift+alt+down | Move Line Down | ✅
 shift+alt+up | shift+alt+up | Move Line Up | ✅
-shift+ctrl+8 | shift+cmd+8 | Column Selection Mode | ✅
+shift+alt+insert | shift+cmd+8 | Column Selection Mode | ✅
 
 ### Search/Replace
 

--- a/package.json
+++ b/package.json
@@ -415,7 +415,7 @@
                 "intellij": "Move Line Up"
             },
             {
-                "key": "shift+ctrl+8",
+                "key": "shift+alt+insert",
                 "mac": "shift+cmd+8",
                 "command": "editor.action.toggleColumnSelection",
                 "intellij": "Column Selection Mode"

--- a/src/package-with-comment.json
+++ b/src/package-with-comment.json
@@ -556,7 +556,7 @@
                 "intellij": "Move Line Up"
             },
             {
-                "key": "shift+ctrl+8",
+                "key": "shift+alt+insert",
                 "mac": "shift+cmd+8",
                 "command": "editor.action.toggleColumnSelection",
                 "intellij": "Column Selection Mode"


### PR DESCRIPTION
the default of intellij `Column Selection mode` in windows should be `alt+shift+insert`

![image](https://user-images.githubusercontent.com/45906942/158721810-7077f635-e715-4946-8cf1-e5b4dd87b445.png)
