### PR TITLE
Support go to supermethod

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ ctrl+alt+b | cmd+alt+b | Go to implementation(s) | ✅
 ctrl+shift+i | alt+space | Open quick definition lookup | ✅
 N/A | cmd+y | Open quick definition lookup | ✅
 ctrl+shift+b | ctrl+shift+b | Go to type declaration | ✅
-ctrl+u | cmd+u | Go to super-method/super-class | N/A
+ctrl+u | cmd+u | Go to super-method/super-class | ✅
 alt+up | ctrl+up | Go to previous method | N/A
 alt+down | ctrl+down | Go to next method | N/A
 ctrl+] | cmd+] | Move to code block end | N/A

--- a/package.json
+++ b/package.json
@@ -749,7 +749,13 @@
                 "intellij": "Go to type declaration",
                 "todo": "not working"
             },
-            
+            {
+                "key": "ctrl+u",
+                "mac": "cmd+u",
+                "command": "java.action.navigateToSuperImplementation",
+                "when": "editorTextFocus && java:serverMode == Standard",
+                "intellij": "Go to super-method/super-class"
+            },
             
             
             

--- a/src/package-with-comment.json
+++ b/src/package-with-comment.json
@@ -1033,16 +1033,13 @@
                 "intellij": "Go to type declaration",
                 "todo": "not working"
             },
-            /*
             {
                 "key": "ctrl+u",
                 "mac": "cmd+u",
-                "command": "",
-                "when": "editorTextFocus",
-                "intellij": "Go to super-method/super-class",
-                "todo": "N/A"
+                "command": "java.action.navigateToSuperImplementation",
+                "when": "editorTextFocus && java:serverMode == Standard",
+                "intellij": "Go to super-method/super-class"
             },
-*/
             /*
             {
                 "key": "alt+up",


### PR DESCRIPTION
Since VS Code Java support has supported go to super implementation, see: https://github.com/redhat-developer/vscode-java/pull/1395

This feature is available when Java language server started, so I add a when clause `java:serverMode == Standard` to avoid missing command bug.