### PR TITLE
Support Extract Field

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ ctrl+f6 | cmd+f6 | Change Signature | N/A
 ctrl+alt+n | cmd+alt+n | Inline | N/A
 ctrl+alt+m | cmd+alt+m | Extract Method | ✅
 ctrl+alt+v | cmd+alt+v | Extract Variable | ✅
-ctrl+alt+f | cmd+alt+f | Extract Field | N/A
+ctrl+alt+f | cmd+alt+f | Extract Field | ✅
 ctrl+alt+c | cmd+alt+c | Extract Constant | N/A
 ctrl+alt+p | cmd+alt+p | Extract Parameter | N/A
 

--- a/package.json
+++ b/package.json
@@ -920,7 +920,17 @@
                     "apply": "ifSingle"
                 }
             },
-            
+            {
+                "key": "ctrl+alt+f",
+                "mac": "cmd+alt+f",
+                "command": "editor.action.codeAction",
+                "when": "editorTextFocus",
+                "intellij": "Extract Field",
+                "args": {
+                    "kind": "refactor.extract.field",
+                    "apply": "ifSingle"
+                }
+            },
             
             
             

--- a/src/package-with-comment.json
+++ b/src/package-with-comment.json
@@ -1337,16 +1337,17 @@
                     "apply": "ifSingle"
                 }
             },
-            /*
             {
                 "key": "ctrl+alt+f",
                 "mac": "cmd+alt+f",
-                "command": "",
+                "command": "editor.action.codeAction",
                 "when": "editorTextFocus",
                 "intellij": "Extract Field",
-                "todo": "N/A"
+                "args": {
+                    "kind": "refactor.extract.field",
+                    "apply": "ifSingle"
+                }
             },
-*/
             /*
             {
                 "key": "ctrl+alt+c",


### PR DESCRIPTION
Since extract field refactor has been supported in VS Code Java support, see: https://github.com/redhat-developer/vscode-java/pull/971, we can enable this.