### PR TITLE
Support extract constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ ctrl+alt+n | cmd+alt+n | Inline | N/A
 ctrl+alt+m | cmd+alt+m | Extract Method | ✅
 ctrl+alt+v | cmd+alt+v | Extract Variable | ✅
 ctrl+alt+f | cmd+alt+f | Extract Field | N/A
-ctrl+alt+c | cmd+alt+c | Extract Constant | N/A
+ctrl+alt+c | cmd+alt+c | Extract Constant | ✅
 ctrl+alt+p | cmd+alt+p | Extract Parameter | N/A
 
 ### VCS/Local History

--- a/package.json
+++ b/package.json
@@ -916,12 +916,22 @@
                 "when": "editorTextFocus",
                 "intellij": "Extract Variable",
                 "args": {
-                    "kind": "refactor.extract.constant",
+                    "kind": "refactor.extract.variable",
                     "apply": "ifSingle"
                 }
             },
             
-            
+            {
+                "key": "ctrl+alt+c",
+                "mac": "cmd+alt+c",
+                "command": "editor.action.codeAction",
+                "when": "editorTextFocus",
+                "intellij": "Extract Constant",
+                "args": {
+                    "kind": "refactor.extract.constant",
+                    "apply": "ifSingle"
+                }
+            },
             
             
             {

--- a/src/package-with-comment.json
+++ b/src/package-with-comment.json
@@ -1333,7 +1333,7 @@
                 "when": "editorTextFocus",
                 "intellij": "Extract Variable",
                 "args": {
-                    "kind": "refactor.extract.constant",
+                    "kind": "refactor.extract.variable",
                     "apply": "ifSingle"
                 }
             },
@@ -1347,16 +1347,17 @@
                 "todo": "N/A"
             },
 */
-            /*
             {
                 "key": "ctrl+alt+c",
                 "mac": "cmd+alt+c",
-                "command": "",
+                "command": "editor.action.codeAction",
                 "when": "editorTextFocus",
                 "intellij": "Extract Constant",
-                "todo": "N/A"
+                "args": {
+                    "kind": "refactor.extract.constant",
+                    "apply": "ifSingle"
+                }
             },
-*/
             /*
             {
                 "key": "ctrl+alt+p",


### PR DESCRIPTION
Since extract constant refactor has been supported in VS Code Java support, see: https://github.com/redhat-developer/vscode-java/pull/965, we can enable this.