### PR TITLE
Fix view breakpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -577,7 +577,7 @@
             {
                 "key": "ctrl+shift+f8",
                 "mac": "cmd+shift+f8",
-                "command": "workbench.view.debug",
+                "command": "workbench.debug.action.focusBreakpointsView",
                 "intellij": "View breakpoints"
             },
             

--- a/src/package-with-comment.json
+++ b/src/package-with-comment.json
@@ -809,7 +809,7 @@
             {
                 "key": "ctrl+shift+f8",
                 "mac": "cmd+shift+f8",
-                "command": "workbench.view.debug",
+                "command": "workbench.debug.action.focusBreakpointsView",
                 "intellij": "View breakpoints"
             },
             /*---------------------------------------------------------------*\


### PR DESCRIPTION
in VS Code, we can use `workbench.debug.action.focusBreakpointsView` to focus the specific breakpoints view, not the debug view container.