### PR TITLE
Support Go to Test

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ ctrl+alt+shift+down | ctrl+alt+shift+down | Next Change | ✅
 ctrl+alt+shift+up | ctrl+alt+shift+up | Previous Change | ✅
 ctrl+home | cmd+home | Move Caret to Text Start | ✅
 ctrl+end | cmd+end | Move Caret to Text End | ✅
+ctrl+shift+t | cmd+shift+t | Go to Test | ✅
 
 ### Refactoring
 

--- a/package.json
+++ b/package.json
@@ -862,6 +862,13 @@
                 "when": "textInputFocus",
                 "intellij": "Move Caret to Text End"
             },
+            {
+                "key": "ctrl+shift+t",
+                "mac": "cmd+shift+t",
+                "command": "java.test.goToTest",
+                "when": "editorTextFocus && java:testRunnerActivated",
+                "intellij": "Go to Test"
+            },
             
             
             {

--- a/src/package-with-comment.json
+++ b/src/package-with-comment.json
@@ -1241,6 +1241,13 @@
                 "when": "textInputFocus",
                 "intellij": "Move Caret to Text End"
             },
+            {
+                "key": "ctrl+shift+t",
+                "mac": "cmd+shift+t",
+                "command": "java.test.goToTest",
+                "when": "editorTextFocus && java:testRunnerActivated",
+                "intellij": "Go to Test"
+            },
             /*---------------------------------------------------------------*\
              * Refactoring
             \*---------------------------------------------------------------*/


### PR DESCRIPTION
IntelliJ:
![image](https://user-images.githubusercontent.com/45906942/158729286-b1f3df97-955c-4e8c-858b-4d475038172e.png)

VSCode:
![gototest](https://user-images.githubusercontent.com/45906942/158729299-6cfe68b2-af40-4f20-8842-37bfd507b555.gif)

Go to Test feature has been support in [Test Runner for Java](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-test), which is included by [extension pack for Java](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-pack), the default recommendation extension for Java project in VS Code. Here I just add a when clause `java:testRunnerActivated` to avoid command missing bug.