### PR TITLE
Add support for the find in folder alternative command

### DIFF
--- a/package.json
+++ b/package.json
@@ -461,6 +461,14 @@
                 "key": "ctrl+shift+f",
                 "mac": "cmd+shift+f",
                 "command": "workbench.action.findInFiles",
+                "when": "!explorerResourceIsFolder || !filesExplorerFocus",
+                "intellij": "Find in path"
+            },
+            {
+                "key": "ctrl+shift+f",
+                "mac": "cmd+shift+f",
+                "command": "filesExplorer.findInFolder",
+                "when": "explorerResourceIsFolder && filesExplorerFocus",
                 "intellij": "Find in path"
             },
             {

--- a/src/package-with-comment.json
+++ b/src/package-with-comment.json
@@ -602,6 +602,14 @@
                 "key": "ctrl+shift+f",
                 "mac": "cmd+shift+f",
                 "command": "workbench.action.findInFiles",
+                "when": "!explorerResourceIsFolder || !filesExplorerFocus",
+                "intellij": "Find in path"
+            },
+            {
+                "key": "ctrl+shift+f",
+                "mac": "cmd+shift+f",
+                "command": "filesExplorer.findInFolder",
+                "when": "explorerResourceIsFolder && filesExplorerFocus",
                 "intellij": "Find in path"
             },
             {


### PR DESCRIPTION
In vscode, cmd+shift+f does find in files when cmd+shift+f is pressed, except for when a folder is selected, in which case it does find in folder.

With the intellij bindings, we only being cmd+shift+f to find in files - I think this should be set up to run in a way similar to vscode core, as otherwise we are loosing functionality?