### PR TITLE
Add Dart version of Go to super-method/super-class (ctrl+u)

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,8 +276,6 @@ Linux, Windows | macOS | Feature | Supported
 ctrl+d | cmd+d | Compare Files | ✅
 f7 | f7 | Next difference | ✅
 shift+f7 | shift+f7 | Previous difference | ✅
-f7 | f7 | Next difference | ✅
-shift+f7 | shift+f7 | Previous difference | ✅
 alt+ctrl+enter | alt+cmd+enter | Start new line before current | ✅
 shift+ctrl+enter | shift+cmd+enter | Start new line | ✅
 alt+f12 | alt+f12 | Opens and focuses corresponding tool window (Terminal) | ✅

--- a/package.json
+++ b/package.json
@@ -771,6 +771,13 @@
                 "when": "editorTextFocus && java:serverMode == Standard",
                 "intellij": "Go to super-method/super-class"
             },
+            {
+                "key": "ctrl+u",
+                "mac": "cmd+u",
+                "command": "dart.goToSuper",
+                "when": "editorTextFocus && editorLangId == 'dart'",
+                "intellij": "Go to super-method/super-class"
+            },
             
             
             

--- a/src/package-with-comment.json
+++ b/src/package-with-comment.json
@@ -1046,6 +1046,13 @@
                 "when": "editorTextFocus && java:serverMode == Standard",
                 "intellij": "Go to super-method/super-class"
             },
+            {
+                "key": "ctrl+u",
+                "mac": "cmd+u",
+                "command": "dart.goToSuper",
+                "when": "editorTextFocus && editorLangId == 'dart'",
+                "intellij": "Go to super-method/super-class"
+            },
             /*
             {
                 "key": "alt+up",

--- a/src/tool/gene-keybind-markdown.js
+++ b/src/tool/gene-keybind-markdown.js
@@ -17,14 +17,33 @@ var mac = null;
 var command = null;
 var intellij = null;
 var supported = null;
-rd.on('line', function(line) {
+var commandsForHeader = new Map();
 
-    if (isHeader(line)) {
-        header = getHeader(line);
+function maybeProcessCurrentSection() {
+    if (header != null) {
         console.log();
         console.log('### ' + header);
         console.log();
         console.log(TABLE_HEADER);
+    }
+    commandsForHeader.forEach(function (hasCommand, format) {
+        if (hasCommand) {
+            console.log(format + '✅');
+        } else {
+            console.log(format + 'N/A');
+        }
+    });
+
+    header = null;
+    commandsForHeader = new Map();
+}
+
+rd.on('line', function(line) {
+
+    if (isHeader(line)) {
+        maybeProcessCurrentSection();
+        header = getHeader(line);
+        commandsForHeader = new Map();
     }
     
     else if (isWindowsOrLinux(line)) {
@@ -43,13 +62,11 @@ rd.on('line', function(line) {
         intellij = getIntelliJ(line);
         
         var format = available(escape(key)) + ' | ' + available(escape(mac)) + ' | ' + intellij + ' | ';
-        if (hasCommand(command)) {
-            console.log(format + '✅');
-        } else {
-            console.log(format + 'N/A');
-        }
+        commandsForHeader.set(format, hasCommand(command) || commandsForHeader.get(format));
     }
 });
+
+maybeProcessCurrentSection(); 
 
 const isHeader         = (line) => line.match(/\* (.*)/)            !== null;
 const isWindowsOrLinux = (line) => line.match(/"key": "(.*)"/)      !== null;
@@ -74,4 +91,4 @@ const available         = (line) => line ? line : 'N/A';
 
 const TABLE_HEADER = 
 `Linux, Windows | macOS | Feature | Supported
----------------|------|---------|---------- `;
+---------------|------|---------|----------`;


### PR DESCRIPTION
First step at anding some Dart specific support to the keybindings to help out Dart/Flutter users that are used to IntelliJ keybindings. 

To land this, I also fixed bug where duplicate lines in the README would appear if there were
multiple entries for the same keyboard shortcut as this was impacting adding adding a Dart shortcut for ctrl+u as well as one existing case.