### PR TITLE
feat: declare the plugin as a UI extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -1355,5 +1355,8 @@
                 "intellij": "Go: Test Previous"
             }
         ]
-    }
+    },
+    "extensionKind": [
+      "ui"
+    ]
 }


### PR DESCRIPTION
Currently, when opening a remote project (ssh/wsl), the plugin does not work and must be reinstalled or `remote.extensionKind` declared in the configuration. But as far as I know, the keymap should work as a UI plugin so that no special handling is required when opening remote projects

![image](https://user-images.githubusercontent.com/24560368/197670798-7e2997d9-e6be-467d-a1a0-83f00fc56235.png)

ref: <https://code.visualstudio.com/api/advanced-topics/remote-extensions#installing-a-development-version-of-your-extension>