### PR TITLE
Include the full set of VS Code "format document" commands

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,4 @@
     },
     "typescript.tsdk": "./node_modules/typescript/lib", // we want to use the TS server from our node_modules folder to control its version
     "editor.formatOnPaste": true,
-    "editor.formatOnSave": true,
 }

--- a/package.json
+++ b/package.json
@@ -215,8 +215,22 @@
             {
                 "key": "ctrl+alt+l",
                 "mac": "cmd+alt+l",
+                "command": "notebook.formatCell",
+                "when": "editorHasDocumentFormattingProvider && editorTextFocus && inCompositeEditor && notebookEditable && !editorReadonly && activeEditor == 'workbench.editor.notebook'",
+                "intellij": "Reformat code"
+            },
+            {
+                "key": "ctrl+alt+l",
+                "mac": "cmd+alt+l",
                 "command": "editor.action.formatDocument",
                 "when": "editorHasDocumentFormattingProvider && editorTextFocus && !editorReadonly && !inCompositeEditor",
+                "intellij": "Reformat code"
+            },
+            {
+                "key": "ctrl+alt+l",
+                "mac": "cmd+alt+l",
+                "command": "editor.action.formatDocument.none",
+                "when": "editorTextFocus && !editorHasDocumentFormattingProvider && !editorReadonly",
                 "intellij": "Reformat code"
             },
             {
@@ -225,6 +239,13 @@
                 "command": "editor.action.formatSelection",
                 "when": "editorHasDocumentSelectionFormattingProvider && editorHasSelection && editorTextFocus && !editorReadonly",
                 "intellij": "Reformat selected code"
+            },
+            {
+                "key": "ctrl+alt+l",
+                "mac": "cmd+alt+l",
+                "command": "notebook.format",
+                "when": "notebookEditable && !editorTextFocus && activeEditor == 'workbench.editor.notebook'",
+                "intellij": "Reformat code"
             },
             {
                 "key": "ctrl+alt+o",

--- a/src/package-with-comment.json
+++ b/src/package-with-comment.json
@@ -270,8 +270,22 @@
             {
                 "key": "ctrl+alt+l",
                 "mac": "cmd+alt+l",
+                "command": "notebook.formatCell",
+                "when": "editorHasDocumentFormattingProvider && editorTextFocus && inCompositeEditor && notebookEditable && !editorReadonly && activeEditor == 'workbench.editor.notebook'",
+                "intellij": "Reformat code"
+            },
+            {
+                "key": "ctrl+alt+l",
+                "mac": "cmd+alt+l",
                 "command": "editor.action.formatDocument",
                 "when": "editorHasDocumentFormattingProvider && editorTextFocus && !editorReadonly && !inCompositeEditor",
+                "intellij": "Reformat code"
+            },
+            {
+                "key": "ctrl+alt+l",
+                "mac": "cmd+alt+l",
+                "command": "editor.action.formatDocument.none",
+                "when": "editorTextFocus && !editorHasDocumentFormattingProvider && !editorReadonly",
                 "intellij": "Reformat code"
             },
             {
@@ -280,6 +294,13 @@
                 "command": "editor.action.formatSelection",
                 "when": "editorHasDocumentSelectionFormattingProvider && editorHasSelection && editorTextFocus && !editorReadonly",
                 "intellij": "Reformat selected code"
+            },
+            {
+                "key": "ctrl+alt+l",
+                "mac": "cmd+alt+l",
+                "command": "notebook.format",
+                "when": "notebookEditable && !editorTextFocus && activeEditor == 'workbench.editor.notebook'",
+                "intellij": "Reformat code"
             },
             {
                 "key": "ctrl+alt+o",


### PR DESCRIPTION
IntelliJ has a set of 4 commands that are used when `option+shift+f` is pressed to run format document, however, only 1 of them is mapped to `cmd+option+l`.

This PR updating the keybindings to include all the format document commands in their various permutations.