### PR TITLE
Fix a bug which will cause failed

### DIFF
--- a/src/importer/parser/IntelliJXmlParser.ts
+++ b/src/importer/parser/IntelliJXmlParser.ts
@@ -6,10 +6,7 @@ import { IntelliJKeymapXML } from '../model/intellij/implement/IntelliJKeymapXML
 import { USE_DEFAULT_FILE } from '../reader/FileOpenDialog';
 
 export class IntelliJXMLParser {
-    private static readonly ALWAYS_ARRAY: string[] = [
-        "keymap.action",
-        "keymap.action.keyboard-shortcut"
-    ];
+    private static readonly ALWAYS_ARRAY: string[] = ['keymap.action', 'keymap.action.keyboard-shortcut'];
 
     static parseToJson(xml: string | USE_DEFAULT_FILE): any | USE_DEFAULT_FILE {
         if (!xml) {
@@ -22,7 +19,7 @@ export class IntelliJXMLParser {
             parseAttributeValue: true,
             isArray: (tagName: string, jpath: string, isLeafNode: boolean, isAttribute: boolean) => {
                 return IntelliJXMLParser.ALWAYS_ARRAY.includes(jpath);
-            }
+            },
         };
         const parser = new XMLParser(parserXmlOptions);
         try {
@@ -43,12 +40,17 @@ export class IntelliJXMLParser {
             const actionIdAttr = actionElements[actionIndex]['@_id'];
             const keystorkeElements = actionElements[actionIndex]['keyboard-shortcut'];
 
-            for (const keystrokeIndex in keystorkeElements) {
-                const keyboardShortcutElement = keystorkeElements[keystrokeIndex];
-                const firstKeystrokeAttr = keyboardShortcutElement['@_first-keystroke'];
-                const secondKeystrokeAttr = keyboardShortcutElement['@_second-keystroke'];
-                const intellijKeymapXml = new IntelliJKeymapXML(actionIdAttr, firstKeystrokeAttr, secondKeystrokeAttr);
-                intellijKeymaps.push(intellijKeymapXml);
+            if (keystorkeElements instanceof Array) {
+                keystorkeElements.forEach((keyboardShortcutElement: any) => {
+                    const firstKeystrokeAttr = keyboardShortcutElement['@_first-keystroke'];
+                    const secondKeystrokeAttr = keyboardShortcutElement['@_second-keystroke'];
+                    const intellijKeymapXml = new IntelliJKeymapXML(
+                        actionIdAttr,
+                        firstKeystrokeAttr,
+                        secondKeystrokeAttr
+                    );
+                    intellijKeymaps.push(intellijKeymapXml);
+                });
             }
         }
         return intellijKeymaps;


### PR DESCRIPTION
Use `Array.forEach` instead of for-in to avoid iterate over internal properties of `keystorkeElements`. It will cause a crash because `keystrokeIndex` will be `'distinct'` instead of real index, and it will make `keyboardShortcutElement` to be a function. `firstKeystrokeAttr` & `secondKeystrokeAttr` will be undefined.