### PR TITLE
Add support for `Use "CamelHumps" words`

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,11 @@ shift+alt+tab | shift+alt+tab | Goto previous splitter | ✅
 enter | enter | Open Highlighted File (Explorer) | ✅
 alt+home | alt+home | Jump to Navigation Bar | ✅
 
+### CamelHumps
+
+If you enable the setting `Use "CamelHumps" words` in IntelliJ, commands like ctrl+left will go to the previous hump in camel case words, rather than the start of the word.
+For similar functionality in VS Code, enalbe the config `config.intellij-idea-keybindings.useCamelHumpsWords` under Settings.
+
 ### IntelliJ Importer
 
 ![IntelliJ Importer](images/usage_intellij_importer.gif)

--- a/package.json
+++ b/package.json
@@ -381,14 +381,14 @@
                 "key": "ctrl+left",
                 "mac": "alt+left",
                 "command": "cursorWordLeft",
-                "when": "editorTextFocus && config.intellij-idea-keybindings.useCamelHumpsWords",
+                "when": "editorTextFocus && !config.intellij-idea-keybindings.useCamelHumpsWords",
                 "intellij": "Cursor to word start"
             },
             {
                 "key": "ctrl+left",
                 "mac": "alt+left",
                 "command": "cursorWordPartStartLeft",
-                "when": "editorTextFocus && !config.intellij-idea-keybindings.useCamelHumpsWords",
+                "when": "editorTextFocus && config.intellij-idea-keybindings.useCamelHumpsWords",
                 "intellij": "Cursor to hump start"
             },
             {
@@ -409,14 +409,14 @@
                 "key": "ctrl+shift+left",
                 "mac": "alt+shift+left",
                 "command": "cursorWordLeftSelect",
-                "when": "editorTextFocus && config.intellij-idea-keybindings.useCamelHumpsWords",
+                "when": "editorTextFocus && !config.intellij-idea-keybindings.useCamelHumpsWords",
                 "intellij": "Select to word start"
             },
             {
                 "key": "ctrl+shift+left",
                 "mac": "alt+shift+left",
                 "command": "cursorWordPartStartLeftSelect",
-                "when": "editorTextFocus && !config.intellij-idea-keybindings.useCamelHumpsWords",
+                "when": "editorTextFocus && config.intellij-idea-keybindings.useCamelHumpsWords",
                 "intellij": "Select to hump start"
             },
             {
@@ -437,14 +437,14 @@
                 "key": "ctrl+backspace",
                 "mac": "alt+backspace",
                 "command": "deleteWordLeft",
-                "when": "editorTextFocus && !editorReadonly && config.intellij-idea-keybindings.useCamelHumpsWords",
+                "when": "editorTextFocus && !editorReadonly && !config.intellij-idea-keybindings.useCamelHumpsWords",
                 "intellij": "Delete to word start"
             },
             {
                 "key": "ctrl+backspace",
                 "mac": "alt+backspace",
                 "command": "deleteWordPartLeft",
-                "when": "editorTextFocus && !editorReadonly && !config.intellij-idea-keybindings.useCamelHumpsWords",
+                "when": "editorTextFocus && !editorReadonly && config.intellij-idea-keybindings.useCamelHumpsWords",
                 "intellij": "Delete to hump start"
             },
             {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
             "properties": {
                 "intellij-idea-keybindings.useCamelHumpsWords": {
                     "type": "boolean",
-                    "default": "false",
+                    "default": false,
                     "description": "Use \"CamelHumps\" words"
                 }
             }

--- a/package.json
+++ b/package.json
@@ -72,6 +72,17 @@
         "url": "https://github.com/sponsors/kasecato"
     },
     "contributes": {
+        "configuration": {
+            "type": "object",
+            "title": "IntelliJ IDEA Keybindings",
+            "properties": {
+                "intellij-idea-keybindings.useCamelHumpsWords": {
+                    "type": "boolean",
+                    "default": "false",
+                    "description": "Use \"CamelHumps\" words"
+                }
+            }
+        },
         "commands": [
             {
                 "command": "intellij.importKeyMapsSchema",
@@ -353,11 +364,88 @@
             
             
             {
+                "key": "ctrl+right",
+                "mac": "alt+right",
+                "command": "cursorWordRight",
+                "when": "editorTextFocus && !config.intellij-idea-keybindings.useCamelHumpsWords",
+                "intellij": "Cursor to word end"
+            },
+            {
+                "key": "ctrl+right",
+                "mac": "alt+right",
+                "command": "cursorWordPartRight",
+                "when": "editorTextFocus && config.intellij-idea-keybindings.useCamelHumpsWords",
+                "intellij": "Cursor to hump end"
+            },
+            {
+                "key": "ctrl+left",
+                "mac": "alt+left",
+                "command": "cursorWordLeft",
+                "when": "editorTextFocus && config.intellij-idea-keybindings.useCamelHumpsWords",
+                "intellij": "Cursor to word start"
+            },
+            {
+                "key": "ctrl+left",
+                "mac": "alt+left",
+                "command": "cursorWordPartStartLeft",
+                "when": "editorTextFocus && !config.intellij-idea-keybindings.useCamelHumpsWords",
+                "intellij": "Cursor to hump start"
+            },
+            {
+                "key": "ctrl+shift+right",
+                "mac": "alt+shift+right",
+                "command": "cursorWordRightSelect",
+                "when": "editorTextFocus && !config.intellij-idea-keybindings.useCamelHumpsWords",
+                "intellij": "Select to word end"
+            },
+            {
+                "key": "ctrl+shift+right",
+                "mac": "alt+shift+right",
+                "command": "cursorWordPartRightSelect",
+                "when": "editorTextFocus && config.intellij-idea-keybindings.useCamelHumpsWords",
+                "intellij": "Select to hump end"
+            },
+            {
+                "key": "ctrl+shift+left",
+                "mac": "alt+shift+left",
+                "command": "cursorWordLeftSelect",
+                "when": "editorTextFocus && config.intellij-idea-keybindings.useCamelHumpsWords",
+                "intellij": "Select to word start"
+            },
+            {
+                "key": "ctrl+shift+left",
+                "mac": "alt+shift+left",
+                "command": "cursorWordPartStartLeftSelect",
+                "when": "editorTextFocus && !config.intellij-idea-keybindings.useCamelHumpsWords",
+                "intellij": "Select to hump start"
+            },
+            {
                 "key": "ctrl+delete",
                 "mac": "alt+delete",
                 "command": "deleteWordRight",
-                "when": "editorTextFocus && !editorReadonly",
+                "when": "editorTextFocus && !editorReadonly && !config.intellij-idea-keybindings.useCamelHumpsWords",
                 "intellij": "Delete to word end"
+            },
+            {
+                "key": "ctrl+delete",
+                "mac": "alt+delete",
+                "command": "deleteWordPartRight",
+                "when": "editorTextFocus && !editorReadonly && config.intellij-idea-keybindings.useCamelHumpsWords",
+                "intellij": "Delete to hump end"
+            },
+            {
+                "key": "ctrl+backspace",
+                "mac": "alt+backspace",
+                "command": "deleteWordLeft",
+                "when": "editorTextFocus && !editorReadonly && config.intellij-idea-keybindings.useCamelHumpsWords",
+                "intellij": "Delete to word start"
+            },
+            {
+                "key": "ctrl+backspace",
+                "mac": "alt+backspace",
+                "command": "deleteWordPartLeft",
+                "when": "editorTextFocus && !editorReadonly && !config.intellij-idea-keybindings.useCamelHumpsWords",
+                "intellij": "Delete to hump start"
             },
             {
                 "key": "ctrl+backspace",

--- a/src/package-with-comment.json
+++ b/src/package-with-comment.json
@@ -513,14 +513,14 @@
                 "key": "ctrl+left",
                 "mac": "alt+left",
                 "command": "cursorWordLeft",
-                "when": "editorTextFocus && config.intellij-idea-keybindings.useCamelHumpsWords",
+                "when": "editorTextFocus && !config.intellij-idea-keybindings.useCamelHumpsWords",
                 "intellij": "Cursor to word start"
             },
             {
                 "key": "ctrl+left",
                 "mac": "alt+left",
                 "command": "cursorWordPartStartLeft",
-                "when": "editorTextFocus && !config.intellij-idea-keybindings.useCamelHumpsWords",
+                "when": "editorTextFocus && config.intellij-idea-keybindings.useCamelHumpsWords",
                 "intellij": "Cursor to hump start"
             },
             {
@@ -541,14 +541,14 @@
                 "key": "ctrl+shift+left",
                 "mac": "alt+shift+left",
                 "command": "cursorWordLeftSelect",
-                "when": "editorTextFocus && config.intellij-idea-keybindings.useCamelHumpsWords",
+                "when": "editorTextFocus && !config.intellij-idea-keybindings.useCamelHumpsWords",
                 "intellij": "Select to word start"
             },
             {
                 "key": "ctrl+shift+left",
                 "mac": "alt+shift+left",
                 "command": "cursorWordPartStartLeftSelect",
-                "when": "editorTextFocus && !config.intellij-idea-keybindings.useCamelHumpsWords",
+                "when": "editorTextFocus && config.intellij-idea-keybindings.useCamelHumpsWords",
                 "intellij": "Select to hump start"
             },
             {
@@ -569,14 +569,14 @@
                 "key": "ctrl+backspace",
                 "mac": "alt+backspace",
                 "command": "deleteWordLeft",
-                "when": "editorTextFocus && !editorReadonly && config.intellij-idea-keybindings.useCamelHumpsWords",
+                "when": "editorTextFocus && !editorReadonly && !config.intellij-idea-keybindings.useCamelHumpsWords",
                 "intellij": "Delete to word start"
             },
             {
                 "key": "ctrl+backspace",
                 "mac": "alt+backspace",
                 "command": "deleteWordPartLeft",
-                "when": "editorTextFocus && !editorReadonly && !config.intellij-idea-keybindings.useCamelHumpsWords",
+                "when": "editorTextFocus && !editorReadonly && config.intellij-idea-keybindings.useCamelHumpsWords",
                 "intellij": "Delete to hump start"
             },
             {

--- a/src/package-with-comment.json
+++ b/src/package-with-comment.json
@@ -78,7 +78,7 @@
             "properties": {
                 "intellij-idea-keybindings.useCamelHumpsWords": {
                     "type": "boolean",
-                    "default": "false",
+                    "default": false,
                     "description": "Use \"CamelHumps\" words"
                 }
             }

--- a/src/package-with-comment.json
+++ b/src/package-with-comment.json
@@ -72,6 +72,17 @@
         "url": "https://github.com/sponsors/kasecato"
     },
     "contributes": {
+        "configuration": {
+            "type": "object",
+            "title": "IntelliJ IDEA Keybindings",
+            "properties": {
+                "intellij-idea-keybindings.useCamelHumpsWords": {
+                    "type": "boolean",
+                    "default": "false",
+                    "description": "Use \"CamelHumps\" words"
+                }
+            }
+        },
         "commands": [
             {
                 "command": "intellij.importKeyMapsSchema",
@@ -485,18 +496,88 @@
             },
 */
             {
+                "key": "ctrl+right",
+                "mac": "alt+right",
+                "command": "cursorWordRight",
+                "when": "editorTextFocus && !config.intellij-idea-keybindings.useCamelHumpsWords",
+                "intellij": "Cursor to word end"
+            },
+            {
+                "key": "ctrl+right",
+                "mac": "alt+right",
+                "command": "cursorWordPartRight",
+                "when": "editorTextFocus && config.intellij-idea-keybindings.useCamelHumpsWords",
+                "intellij": "Cursor to hump end"
+            },
+            {
+                "key": "ctrl+left",
+                "mac": "alt+left",
+                "command": "cursorWordLeft",
+                "when": "editorTextFocus && config.intellij-idea-keybindings.useCamelHumpsWords",
+                "intellij": "Cursor to word start"
+            },
+            {
+                "key": "ctrl+left",
+                "mac": "alt+left",
+                "command": "cursorWordPartStartLeft",
+                "when": "editorTextFocus && !config.intellij-idea-keybindings.useCamelHumpsWords",
+                "intellij": "Cursor to hump start"
+            },
+            {
+                "key": "ctrl+shift+right",
+                "mac": "alt+shift+right",
+                "command": "cursorWordRightSelect",
+                "when": "editorTextFocus && !config.intellij-idea-keybindings.useCamelHumpsWords",
+                "intellij": "Select to word end"
+            },
+            {
+                "key": "ctrl+shift+right",
+                "mac": "alt+shift+right",
+                "command": "cursorWordPartRightSelect",
+                "when": "editorTextFocus && config.intellij-idea-keybindings.useCamelHumpsWords",
+                "intellij": "Select to hump end"
+            },
+            {
+                "key": "ctrl+shift+left",
+                "mac": "alt+shift+left",
+                "command": "cursorWordLeftSelect",
+                "when": "editorTextFocus && config.intellij-idea-keybindings.useCamelHumpsWords",
+                "intellij": "Select to word start"
+            },
+            {
+                "key": "ctrl+shift+left",
+                "mac": "alt+shift+left",
+                "command": "cursorWordPartStartLeftSelect",
+                "when": "editorTextFocus && !config.intellij-idea-keybindings.useCamelHumpsWords",
+                "intellij": "Select to hump start"
+            },
+            {
                 "key": "ctrl+delete",
                 "mac": "alt+delete",
                 "command": "deleteWordRight",
-                "when": "editorTextFocus && !editorReadonly",
+                "when": "editorTextFocus && !editorReadonly && !config.intellij-idea-keybindings.useCamelHumpsWords",
                 "intellij": "Delete to word end"
+            },
+            {
+                "key": "ctrl+delete",
+                "mac": "alt+delete",
+                "command": "deleteWordPartRight",
+                "when": "editorTextFocus && !editorReadonly && config.intellij-idea-keybindings.useCamelHumpsWords",
+                "intellij": "Delete to hump end"
             },
             {
                 "key": "ctrl+backspace",
                 "mac": "alt+backspace",
                 "command": "deleteWordLeft",
-                "when": "editorTextFocus && !editorReadonly",
+                "when": "editorTextFocus && !editorReadonly && config.intellij-idea-keybindings.useCamelHumpsWords",
                 "intellij": "Delete to word start"
+            },
+            {
+                "key": "ctrl+backspace",
+                "mac": "alt+backspace",
+                "command": "deleteWordPartLeft",
+                "when": "editorTextFocus && !editorReadonly && !config.intellij-idea-keybindings.useCamelHumpsWords",
+                "intellij": "Delete to hump start"
             },
             {
                 "key": "ctrl+=",


### PR DESCRIPTION
Potential solution for https://github.com/kasecato/vscode-intellij-idea-keybindings/issues/300

Not sure about the wording in the readme file - but let me know what you think about this as an approach?