### PR TITLE
Update shift+escape to Hide Active Tool Window

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,12 +153,7 @@ alt+right | ctrl+right | Go to next editor tab | ✅
 N/A | shift+cmd+] | Go to next editor tab | ✅
 f12 | f12 | Go back to previous tool window | N/A
 escape | escape | Go to editor (from tool window) | N/A
-shift+escape | shift+escape | Hide active or last active window (Sidebar) | ✅
-shift+escape | shift+escape | Hide active or last active window (Output) | ✅
-shift+escape | shift+escape | Hide active or last active window (Problems) | ✅
-shift+escape | shift+escape | Hide active or last active window (Debug Console) | ✅
-shift+escape | shift+escape | Hide active or last active window (Terminal) | ✅
-shift+escape | shift+escape | Hide active or last active window (Panel) | N/A
+shift+escape | shift+escape | Hide Active Tool Window | ✅
 ctrl+shift+f4 | cmd+shift+f4 | Close active run/messages/find/... tab | N/A
 ctrl+shift+' | cmd+shift+' | Maximize Tool Window (Problems, Output, Debug Console, Terminal) | ✅
 ctrl+g | cmd+l | Go to line | ✅

--- a/package.json
+++ b/package.json
@@ -838,30 +838,23 @@
                 "key": "shift+escape",
                 "mac": "shift+escape",
                 "command": "workbench.action.toggleSidebarVisibility",
-                "when": "!editorFocus && !terminalFocus && !problemFocus && !inDebugRepl",
-                "intellij": "Hide active or last active window (Sidebar)"
-            },
-            
-            {
-                "key": "shift+escape",
-                "mac": "shift+escape",
-                "command": "workbench.actions.view.problems",
-                "intellij": "Hide active or last active window (Problems)"
+                "when": "sideBarFocus",
+                "intellij": "Hide Active Tool Window"
             },
             {
                 "key": "shift+escape",
                 "mac": "shift+escape",
-                "command": "workbench.debug.action.toggleRepl",
-                "when": "debuggersAvailable",
-                "intellij": "Hide active or last active window (Debug Console)"
+                "command": "workbench.action.toggleAuxiliaryBar",
+                "when": "auxiliaryBarFocus",
+                "intellij": "Hide Active Tool Window"
             },
             {
                 "key": "shift+escape",
                 "mac": "shift+escape",
-                "command": "workbench.action.terminal.toggleTerminal",
-                "intellij": "Hide active or last active window (Terminal)"
+                "command": "workbench.action.togglePanel",
+                "when": "panelFocus",
+                "intellij": "Hide Active Tool Window"
             },
-            
             
             {
                 "key": "ctrl+shift+'",

--- a/src/package-with-comment.json
+++ b/src/package-with-comment.json
@@ -1079,47 +1079,23 @@
                 "key": "shift+escape",
                 "mac": "shift+escape",
                 "command": "workbench.action.toggleSidebarVisibility",
-                "when": "!editorFocus && !terminalFocus && !problemFocus && !inDebugRepl",
-                "intellij": "Hide active or last active window (Sidebar)"
-            },
-            /*
-            {
-                "key": "shift+escape",
-                "mac": "shift+escape",
-                "command": "workbench.action.output.toggleOutput",
-                "when": "outputFocus",
-                "intellij": "Hide active or last active window (Output)"
-            },
-*/
-            {
-                "key": "shift+escape",
-                "mac": "shift+escape",
-                "command": "workbench.actions.view.problems",
-                "intellij": "Hide active or last active window (Problems)"
+                "when": "sideBarFocus",
+                "intellij": "Hide Active Tool Window"
             },
             {
                 "key": "shift+escape",
                 "mac": "shift+escape",
-                "command": "workbench.debug.action.toggleRepl",
-                "when": "debuggersAvailable",
-                "intellij": "Hide active or last active window (Debug Console)"
+                "command": "workbench.action.toggleAuxiliaryBar",
+                "when": "auxiliaryBarFocus",
+                "intellij": "Hide Active Tool Window"
             },
             {
                 "key": "shift+escape",
                 "mac": "shift+escape",
-                "command": "workbench.action.terminal.toggleTerminal",
-                "intellij": "Hide active or last active window (Terminal)"
+                "command": "workbench.action.togglePanel",
+                "when": "panelFocus",
+                "intellij": "Hide Active Tool Window"
             },
-            /*
-            {
-                "key": "shift+escape",
-                "mac": "shift+escape",
-                "command": "",
-                "when": "panelVisible",
-                "intellij": "Hide active or last active window (Panel)",
-                "todo": "not support panelVisible VS Code #14779"
-            },
-*/
             /*
             {
                 "key": "ctrl+shift+f4",


### PR DESCRIPTION
Perform the equivalent of IntelliJ ‘Hide Active Tool Window’ by hiding each of the sidebar, secondary sidebar or panel when focused.

Implements https://www.jetbrains.com/help/idea/tool-windows.html#hide_active

Fixes #103.