### PR TITLE
Implement Select Opposite Diff Pane

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ Linux, Windows | macOS | Feature | Supported
 ---------------|------|---------|----------
 ctrl+d | cmd+d | Compare Files | ✅
 ctrl+d | cmd+d | Compare Selected Files | ✅
+ctrl+shift+tab | ctrl+shift+tab | Select Opposite Diff Pane | ✅
 f7 | f7 | Next difference | ✅
 shift+f7 | shift+f7 | Previous difference | ✅
 alt+ctrl+enter | alt+cmd+enter | Start new line before current | ✅

--- a/package.json
+++ b/package.json
@@ -1479,6 +1479,13 @@
                 "intellij": "Compare Selected Files"
             },
             {
+                "key": "ctrl+shift+tab",
+                "mac": "ctrl+shift+tab",
+                "command": "workbench.action.compareEditor.focusOtherSide",
+                "when": "textCompareEditorVisible",
+                "intellij": "Select Opposite Diff Pane"
+            },
+            {
                 "key": "f7",
                 "mac": "f7",
                 "command": "workbench.action.compareEditor.nextChange",

--- a/package.json
+++ b/package.json
@@ -1482,7 +1482,7 @@
                 "key": "ctrl+shift+tab",
                 "mac": "ctrl+shift+tab",
                 "command": "workbench.action.compareEditor.focusOtherSide",
-                "when": "textCompareEditorVisible",
+                "when": "activeCompareEditorCanSwap",
                 "intellij": "Select Opposite Diff Pane"
             },
             {

--- a/src/package-with-comment.json
+++ b/src/package-with-comment.json
@@ -1936,7 +1936,7 @@
                 "key": "ctrl+shift+tab",
                 "mac": "ctrl+shift+tab",
                 "command": "workbench.action.compareEditor.focusOtherSide",
-                "when": "textCompareEditorVisible",
+                "when": "activeCompareEditorCanSwap",
                 "intellij": "Select Opposite Diff Pane"
             },
             {

--- a/src/package-with-comment.json
+++ b/src/package-with-comment.json
@@ -1933,6 +1933,13 @@
                 "intellij": "Compare Selected Files"
             },
             {
+                "key": "ctrl+shift+tab",
+                "mac": "ctrl+shift+tab",
+                "command": "workbench.action.compareEditor.focusOtherSide",
+                "when": "textCompareEditorVisible",
+                "intellij": "Select Opposite Diff Pane"
+            },
+            {
                 "key": "f7",
                 "mac": "f7",
                 "command": "workbench.action.compareEditor.nextChange",


### PR DESCRIPTION
Add diff pane focus toggle to implement the IntelliJ shortcut for ‘[Select Opposite Diff Pane](https://www.jetbrains.com/help/idea/reference-keymap-win-default.html#diff_viewer)’.