### PR TITLE
Complete current statement with semicolon if JS and configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ ctrl+space | ctrl+space | Basic code completion (the name of any class, method o
 ctrl+shift+space | ctrl+shift+space | Smart code completion (filters the list of methods and variables by expected type) | N/A
 enter | enter | Choose Lookup Item | ✅
 tab | tab | Choose Lookup Item Replace | ✅
-ctrl+shift+enter | cmd+shift+enter | Complete statement | ✅
+ctrl+shift+enter | cmd+shift+enter | Complete Current Statement | ✅
 ctrl+p | cmd+p | Parameter info (within method call arguments) | ✅
 ctrl+q | ctrl+j | Quick documentation lookup | ✅
 N/A | f1 | Quick documentation lookup | ✅

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
                         }
                     ]
                 },
-                "when": "suggestWidgetVisible && textInputFocus && (resourceLangId == 'javascript' || resourceLangId == 'typescript') && config.javascript.format.semicolons == 'insert'",
+                "when": "suggestWidgetVisible && textInputFocus && (editorLangId == 'javascript' || editorLangId == 'typescript') && config.javascript.format.semicolons == 'insert'",
                 "intellij": "Complete Current Statement"
             },
             {

--- a/package.json
+++ b/package.json
@@ -112,9 +112,33 @@
             {
                 "key": "ctrl+shift+enter",
                 "mac": "cmd+shift+enter",
+                "command": "runCommands",
+                "args": {
+                    "commands": [
+                        "acceptSelectedSuggestion",
+                        {
+                            "command": "cursorMove",
+                            "args": {
+                                "to": "wrappedLineEnd"
+                            }
+                        },
+                        {
+                            "command": "editor.action.insertSnippet",
+                            "args": {
+                                "snippet": ";"
+                            }
+                        }
+                    ]
+                },
+                "when": "suggestWidgetVisible && textInputFocus && (resourceLangId == 'javascript' || resourceLangId == 'typescript') && config.javascript.format.semicolons == 'insert'",
+                "intellij": "Complete Current Statement"
+            },
+            {
+                "key": "ctrl+shift+enter",
+                "mac": "cmd+shift+enter",
                 "command": "acceptSelectedSuggestion",
                 "when": "suggestWidgetVisible && textInputFocus",
-                "intellij": "Complete statement"
+                "intellij": "Complete Current Statement"
             },
             {
                 "key": "ctrl+p",

--- a/src/package-with-comment.json
+++ b/src/package-with-comment.json
@@ -149,7 +149,7 @@
                         }
                     ]
                 },
-                "when": "suggestWidgetVisible && textInputFocus && (resourceLangId == 'javascript' || resourceLangId == 'typescript') && config.javascript.format.semicolons == 'insert'",
+                "when": "suggestWidgetVisible && textInputFocus && (editorLangId == 'javascript' || editorLangId == 'typescript') && config.javascript.format.semicolons == 'insert'",
                 "intellij": "Complete Current Statement"
             },
             {

--- a/src/package-with-comment.json
+++ b/src/package-with-comment.json
@@ -131,9 +131,33 @@
             {
                 "key": "ctrl+shift+enter",
                 "mac": "cmd+shift+enter",
+                "command": "runCommands",
+                "args": {
+                    "commands": [
+                        "acceptSelectedSuggestion",
+                        {
+                            "command": "cursorMove",
+                            "args": {
+                                "to": "wrappedLineEnd"
+                            }
+                        },
+                        {
+                            "command": "editor.action.insertSnippet",
+                            "args": {
+                                "snippet": ";"
+                            }
+                        }
+                    ]
+                },
+                "when": "suggestWidgetVisible && textInputFocus && (resourceLangId == 'javascript' || resourceLangId == 'typescript') && config.javascript.format.semicolons == 'insert'",
+                "intellij": "Complete Current Statement"
+            },
+            {
+                "key": "ctrl+shift+enter",
+                "mac": "cmd+shift+enter",
                 "command": "acceptSelectedSuggestion",
                 "when": "suggestWidgetVisible && textInputFocus",
-                "intellij": "Complete statement"
+                "intellij": "Complete Current Statement"
             },
             {
                 "key": "ctrl+p",


### PR DESCRIPTION
Fixes #65 by inserting a semicolon at the end of the line if language is JavaScript (or TypeScript) and semicolons are configured as required using the existing `javascript.format.semicolons` configuration option in the JavaScript extension.