### PR TITLE
Support Run Anything shortcut on double ctrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ ctrl+f9 | cmd+f9 | Make project (compile modifed and dependent) | ✅
 ctrl+shift+f9 | cmd+shift+f9 | Compile selected file, package or module | N/A
 alt+shift+f10 | ctrl+alt+r | Select configuration and run | ✅
 alt+shift+f9 | ctrl+alt+d | Select configuration and debug | ✅
+ctrl ctrl | ctrl ctrl | Run Anything | ✅
 shift+f10 | ctrl+r | Run | ✅
 shift+f9 | ctrl+d | Debug | ✅
 ctrl+shift+f10 | ctrl+shift+r | Run context configuration from editor | N/A

--- a/package.json
+++ b/package.json
@@ -726,6 +726,13 @@
                 "intellij": "Select configuration and debug"
             },
             {
+                "key": "ctrl ctrl",
+                "mac": "ctrl ctrl",
+                "command": "workbench.action.tasks.runTask",
+                "when": "taskCommandsRegistered && !terminalFocus",
+                "intellij": "Run Anything"
+            },
+            {
                 "key": "shift+f10",
                 "mac": "ctrl+r",
                 "command": "workbench.action.tasks.reRunTask",

--- a/src/package-with-comment.json
+++ b/src/package-with-comment.json
@@ -922,6 +922,13 @@
                 "intellij": "Select configuration and debug"
             },
             {
+                "key": "ctrl ctrl",
+                "mac": "ctrl ctrl",
+                "command": "workbench.action.tasks.runTask",
+                "when": "taskCommandsRegistered && !terminalFocus",
+                "intellij": "Run Anything"
+            },
+            {
                 "key": "shift+f10",
                 "mac": "ctrl+r",
                 "command": "workbench.action.tasks.reRunTask",


### PR DESCRIPTION
Add support for Run Anything (https://www.jetbrains.com/help/idea/running-anything.html) on double ctrl to open the Run Task picker.