### PR TITLE
Add Go to Next/Prev Symbol Highlight support

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ Linux, Windows | macOS | Feature | Supported
 ---------------|------|---------|----------
 alt+f7 | alt+f7 | Find usages | ✅
 alt+ctrl+f7 | alt+cmd+f7 | Show usages | ✅
+N/A | ctrl+alt+down | Next Highlighted Usage | ✅
+N/A | ctrl+alt+up | Previous Highlighted Usage | ✅
 ctrl+f7 | cmd+f7 | Find usages in file | N/A
 ctrl+shift+f7 | cmd+shift+f7 | Highlight usages in file | N/A
 ctrl+alt+f7 | cmd+alt+f7 | Show usages | N/A

--- a/package.json
+++ b/package.json
@@ -701,6 +701,20 @@
                 "when": "editorHasReferenceProvider && editorTextFocus && !inReferenceSearchEditor",
                 "intellij": "Show usages"
             },
+            {
+                "key": "",
+                "mac": "ctrl+alt+down",
+                "command": "editor.action.wordHighlight.next",
+                "when": "editorTextFocus && hasWordHighlights",
+                "intellij": "Next Highlighted Usage"
+            },
+            {
+                "key": "",
+                "mac": "ctrl+alt+up",
+                "command": "editor.action.wordHighlight.prev",
+                "when": "editorTextFocus && hasWordHighlights",
+                "intellij": "Previous Highlighted Usage"
+            },
             
             
             

--- a/src/package-with-comment.json
+++ b/src/package-with-comment.json
@@ -860,6 +860,20 @@
                 "when": "editorHasReferenceProvider && editorTextFocus && !inReferenceSearchEditor",
                 "intellij": "Show usages"
             },
+            {
+                "key": "",
+                "mac": "ctrl+alt+down",
+                "command": "editor.action.wordHighlight.next",
+                "when": "editorTextFocus && hasWordHighlights",
+                "intellij": "Next Highlighted Usage"
+            },
+            {
+                "key": "",
+                "mac": "ctrl+alt+up",
+                "command": "editor.action.wordHighlight.prev",
+                "when": "editorTextFocus && hasWordHighlights",
+                "intellij": "Previous Highlighted Usage"
+            },
             /*
             {
                 "key": "ctrl+f7",


### PR DESCRIPTION
Added [Go to Next/Prev Symbol Highlight support](https://www.jetbrains.com/help/idea/find-highlight-usages.html#usages_in_file).

close #372 