### PR TITLE
Add shortcut for f4 to jump to source

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ ctrl+shift+k | cmd+alt+k | Push commits to VCS | ✅
 ctrl+t | cmd+t | Update project from VCS | ✅
 ctrl+alt+z | cmd+alt+z | Rollback Lines | ✅
 alt+shift+c | alt+shift+c | View recent changes | N/A
+f4 | f4 | Jump to Source | ✅
 
 ### Live Templates
 

--- a/src/package-with-comment.json
+++ b/src/package-with-comment.json
@@ -1694,6 +1694,13 @@
                 "when": "editorTextFocus && !editorReadonly",
                 "intellij": "Rollback Lines"
             },
+            {
+                "key": "f4",
+                "mac": "f4",
+                "command": "git.openFile",
+                "when": "config.git.enabled && isInDiffEditor",
+                "intellij": "Jump to Source"
+            },
             /*
             {
                 "key": "alt+shift+c",


### PR DESCRIPTION
One of my most used shortcut in IntelliJ was missing. Jumping from a git diff view to the actual file.